### PR TITLE
Add support for inter-age routing of directed messages

### DIFF
--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -118,14 +118,17 @@ void dm_propagate_to(GameHost_Private* host, MOUL::NetMessage* msg,
     pthread_mutex_lock(&host->m_clientMutex);
     std::vector<uint32_t>::const_iterator rcvr_iter;
     for (rcvr_iter = receivers.begin(); rcvr_iter != receivers.end(); ++rcvr_iter) {
-        std::tr1::unordered_map<uint32_t, GameClient_Private*>::iterator client = host->m_clients.find(*rcvr_iter);
-        if (client != host->m_clients.end()) {
-            try {
-                DS::CryptSendBuffer(client->second->m_sock, client->second->m_crypt,
-                                    host->m_buffer.buffer(), host->m_buffer.size());
-            } catch (DS::SockHup) {
-                // This is handled below too, but we don't want to skip the rest
-                // of the client list if one hung up
+        for(hostmap_t::iterator recv_host = s_gameHosts.begin(); recv_host != s_gameHosts.end(); recv_host++) {
+            std::tr1::unordered_map<uint32_t, GameClient_Private*>::iterator client = recv_host->second->m_clients.find(*rcvr_iter);
+            if (client != recv_host->second->m_clients.end()) {
+                try {
+                    DS::CryptSendBuffer(client->second->m_sock, client->second->m_crypt,
+                                        host->m_buffer.buffer(), host->m_buffer.size());
+                } catch (DS::SockHup) {
+                    // This is handled below too, but we don't want to skip the rest
+                    // of the client list if one hung up
+                }
+                break; // Don't bother checking the rest of the hosts, we found the one we're looking for
             }
         }
     }


### PR DESCRIPTION
This changes the handling of NetMsgGameMessageDirected to check all active hosts for a given player ID when trying to find a target. It makes inter-age KI chat work correctly.
