### PR TITLE
Public Age Support

### DIFF
--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -59,6 +59,7 @@ enum AuthDaemonMessages
     e_VaultCreateNode, e_VaultFetchNode, e_VaultUpdateNode, e_VaultRefNode,
     e_VaultUnrefNode, e_VaultFetchNodeTree, e_VaultFindNode, e_VaultInitAge,
     e_AuthFindGameServer, e_AuthDisconnect, e_AuthAddAcct, e_AuthGetPublic,
+    e_AuthSetPublic
 };
 
 struct Auth_AccountInfo
@@ -140,6 +141,12 @@ struct Auth_PubAgeRequest : public Auth_ClientMessage
 
     DS::String m_agename;
     std::vector<pnNetAgeInfo> m_ages;
+};
+
+struct Auth_SetPublic : public Auth_ClientMessage
+{
+    uint32_t m_node;
+    uint8_t m_public;
 };
 
 DS::Blob gen_default_sdl(const DS::String& filename);

--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -704,6 +704,18 @@ void cb_getPublicAges(AuthServer_Private& client)
     SEND_REPLY();
 }
 
+void cb_setAgePublic(AuthServer_Private& client)
+{
+    Auth_SetPublic msg;
+    msg.m_client = &client;
+    msg.m_node = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
+    msg.m_public = DS::CryptRecvValue<uint8_t>(client.m_sock, client.m_crypt);
+
+    s_authChannel.putMessage(e_AuthSetPublic, reinterpret_cast<void*>(&msg));
+
+    client.m_channel.getMessage(); // wait for daemon to finish
+}
+
 void* wk_authWorker(void* sockp)
 {
     AuthServer_Private client;
@@ -795,6 +807,7 @@ void* wk_authWorker(void* sockp)
                 cb_getPublicAges(client);
                 break;
             case e_CliToAuth_SetAgePublic:
+                cb_setAgePublic(client);
                 break;
             case e_CliToAuth_ClientSetCCRLevel:
             case e_CliToAuth_AcctSetRolesRequest:


### PR DESCRIPTION
These patches add support for fetching the public age list and for setting an age as public or private.

Known issues:
- The population counter currently always shows 0 for public areas. I believe this will take some gameserver changes to fix.
