### PR TITLE
Vault publishing fixes

### DIFF
--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -57,9 +57,9 @@ enum AuthDaemonMessages
 {
     e_AuthShutdown, e_AuthClientLogin, e_AuthSetPlayer, e_AuthCreatePlayer,
     e_VaultCreateNode, e_VaultFetchNode, e_VaultUpdateNode, e_VaultRefNode,
-    e_VaultUnrefNode, e_VaultFetchNodeTree, e_VaultFindNode, e_VaultInitAge,
-    e_AuthFindGameServer, e_AuthDisconnect, e_AuthAddAcct, e_AuthGetPublic,
-    e_AuthSetPublic
+    e_VaultUnrefNode, e_VaultFetchNodeTree, e_VaultFindNode, e_VaultSendNode,
+    e_VaultInitAge,  e_AuthFindGameServer, e_AuthDisconnect, e_AuthAddAcct,
+    e_AuthGetPublic, e_AuthSetPublic
 };
 
 struct Auth_AccountInfo
@@ -104,6 +104,13 @@ struct Auth_NodeInfo : public Auth_ClientMessage
 struct Auth_NodeRef : public Auth_ClientMessage
 {
     DS::Vault::NodeRef m_ref;
+};
+
+struct Auth_NodeSend : public Auth_ClientMessage
+{
+    uint32_t m_nodeIdx;
+    uint32_t m_playerIdx;
+    uint32_t m_senderIdx;
 };
 
 struct Auth_NodeRefList : public Auth_ClientMessage

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -708,6 +708,18 @@ void* dm_authDaemon(void*)
                     }
                 }
                 break;
+            case e_VaultSendNode:
+                {
+                    Auth_NodeSend* info = reinterpret_cast<Auth_NodeSend*>(msg.m_payload);
+                    DS::Vault::NodeRef ref = v_send_node(info->m_nodeIdx, info->m_playerIdx, info->m_senderIdx);
+                    if (ref.m_child || ref.m_owner || ref.m_parent)
+                        dm_auth_bcast_ref(ref);
+                    // There's no way to indicate success or failure to the client. Whether or not it gets a NodeRef
+                    // message is the only way the client knows if all went well here.
+                    // This reply is purely for synchronization purposes.
+                    SEND_REPLY(info, 0);
+                }
+                break;
             case e_VaultUnrefNode:
                 {
                     Auth_NodeRef* info = reinterpret_cast<Auth_NodeRef*>(msg.m_payload);

--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -446,9 +446,13 @@ void cb_nodeFind(AuthServer_Private& client)
 
 void cb_nodeSend(AuthServer_Private& client)
 {
-    uint32_t nodeId = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
-    uint32_t playerId = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
-    v_send_node(nodeId, playerId, client.m_player.m_playerId);
+    Auth_NodeSend msg;
+    msg.m_client = &client;
+    msg.m_senderIdx = client.m_player.m_playerId;
+    msg.m_nodeIdx = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
+    msg.m_playerIdx = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
+    s_authChannel.putMessage(e_VaultSendNode, reinterpret_cast<void*>(&msg));
+    client.m_channel.getMessage(); // wait for the vault operation to complete before returning
 }
 
 void cb_ageRequest(AuthServer_Private& client, bool ext)

--- a/AuthServ/AuthServer_Private.h
+++ b/AuthServ/AuthServer_Private.h
@@ -127,4 +127,4 @@ bool v_ref_node(uint32_t parentIdx, uint32_t childIdx, uint32_t ownerIdx);
 bool v_unref_node(uint32_t parentIdx, uint32_t childIdx);
 bool v_fetch_tree(uint32_t nodeId, std::vector<DS::Vault::NodeRef>& refs);
 bool v_find_nodes(const DS::Vault::Node& nodeTemplate, std::vector<uint32_t>& nodes);
-bool v_send_node(uint32_t nodeId, uint32_t playerId, uint32_t senderId);
+DS::Vault::NodeRef v_send_node(uint32_t nodeId, uint32_t playerId, uint32_t senderId);


### PR DESCRIPTION
Three fixes (in two commits) to vault node sending/publishing:
1. Set the owner of the reference to the correct sender, instead of system
2. Handle send messages in a thread-safe way
3. Broadcast ref messages to clients when a node is published
