### PR TITLE
Support for unencrypted connections

### DIFF
--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -43,28 +43,35 @@ void auth_init(AuthServer_Private& client)
     DS::Uuid uuid;
     DS::RecvBuffer(client.m_sock, uuid.m_bytes, sizeof(uuid.m_bytes));
 
-    /* Establish encryption */
+    /* Reply header */
+    client.m_buffer.truncate();
+    client.m_buffer.write<uint8_t>(DS::e_ServToCliEncrypt);
+
+    /* Establish encryption, and write reply body */
     uint8_t msgId = DS::RecvValue<uint8_t>(client.m_sock);
     DS_PASSERT(msgId == DS::e_CliToServConnect);
     uint8_t msgSize = DS::RecvValue<uint8_t>(client.m_sock);
-    DS_PASSERT(msgSize == 66);
+    if (msgSize == 2) { // no seed... client wishes unencrypted connection (that's okay, nobody else can "fake" us as nobody has the private key, so if the client actually wants encryption it will only work with the correct peer)
+        client.m_buffer.write<uint8_t>(2); // reply with an empty seed as well
+    }
+    else {
+        uint8_t Y[64];
+        DS_PASSERT(msgSize == 66);
+        DS::RecvBuffer(client.m_sock, Y, 64);
+        BYTE_SWAP_BUFFER(Y, 64);
 
-    uint8_t Y[64];
-    DS::RecvBuffer(client.m_sock, Y, 64);
-    BYTE_SWAP_BUFFER(Y, 64);
+        uint8_t serverSeed[7];
+        uint8_t sharedKey[7];
+        DS::CryptEstablish(serverSeed, sharedKey, DS::Settings::CryptKey(DS::e_KeyAuth_N),
+                        DS::Settings::CryptKey(DS::e_KeyAuth_K), Y);
+        client.m_crypt = DS::CryptStateInit(sharedKey, 7);
 
-    uint8_t serverSeed[7];
-    uint8_t sharedKey[7];
-    DS::CryptEstablish(serverSeed, sharedKey, DS::Settings::CryptKey(DS::e_KeyAuth_N),
-                       DS::Settings::CryptKey(DS::e_KeyAuth_K), Y);
-
-    client.m_buffer.truncate();
-    client.m_buffer.write<uint8_t>(DS::e_ServToCliEncrypt);
-    client.m_buffer.write<uint8_t>(9);
-    client.m_buffer.writeBytes(serverSeed, 7);
+        client.m_buffer.write<uint8_t>(9);
+        client.m_buffer.writeBytes(serverSeed, 7);
+    }
+    
+    /* send reply */
     DS::SendBuffer(client.m_sock, client.m_buffer.buffer(), client.m_buffer.size());
-
-    client.m_crypt = DS::CryptStateInit(sharedKey, 7);
 }
 
 void cb_ping(AuthServer_Private& client)

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -41,28 +41,35 @@ void game_client_init(GameClient_Private& client)
     DS::RecvBuffer(client.m_sock, clientUuid.m_bytes, sizeof(clientUuid.m_bytes));
     DS::RecvBuffer(client.m_sock, connUuid.m_bytes, sizeof(connUuid.m_bytes));
 
-    /* Establish encryption */
+    /* Reply header */
+    client.m_buffer.truncate();
+    client.m_buffer.write<uint8_t>(DS::e_ServToCliEncrypt);
+
+    /* Establish encryption, and write reply body */
     uint8_t msgId = DS::RecvValue<uint8_t>(client.m_sock);
     DS_PASSERT(msgId == DS::e_CliToServConnect);
     uint8_t msgSize = DS::RecvValue<uint8_t>(client.m_sock);
-    DS_PASSERT(msgSize == 66);
+    if (msgSize == 2) { // no seed... client wishes unencrypted connection (that's okay, nobody else can "fake" us as nobody has the private key, so if the client actually wants encryption it will only work with the correct peer)
+        client.m_buffer.write<uint8_t>(2); // reply with an empty seed as well
+    }
+    else {
+        uint8_t Y[64];
+        DS_PASSERT(msgSize == 66);
+        DS::RecvBuffer(client.m_sock, Y, 64);
+        BYTE_SWAP_BUFFER(Y, 64);
 
-    uint8_t Y[64];
-    DS::RecvBuffer(client.m_sock, Y, 64);
-    BYTE_SWAP_BUFFER(Y, 64);
+        uint8_t serverSeed[7];
+        uint8_t sharedKey[7];
+        DS::CryptEstablish(serverSeed, sharedKey, DS::Settings::CryptKey(DS::e_KeyGame_N),
+                        DS::Settings::CryptKey(DS::e_KeyGame_K), Y);
+        client.m_crypt = DS::CryptStateInit(sharedKey, 7);
 
-    uint8_t serverSeed[7];
-    uint8_t sharedKey[7];
-    DS::CryptEstablish(serverSeed, sharedKey, DS::Settings::CryptKey(DS::e_KeyGame_N),
-                       DS::Settings::CryptKey(DS::e_KeyGame_K), Y);
-
-    client.m_buffer.truncate();
-    client.m_buffer.write<uint8_t>(DS::e_ServToCliEncrypt);
-    client.m_buffer.write<uint8_t>(9);
-    client.m_buffer.writeBytes(serverSeed, 7);
+        client.m_buffer.write<uint8_t>(9);
+        client.m_buffer.writeBytes(serverSeed, 7);
+    }
+    
+    /* send reply */
     DS::SendBuffer(client.m_sock, client.m_buffer.buffer(), client.m_buffer.size());
-
-    client.m_crypt = DS::CryptStateInit(sharedKey, 7);
 }
 
 GameHost_Private* find_game_host(uint32_t ageMcpId)

--- a/GateKeeper/GateServ.cpp
+++ b/GateKeeper/GateServ.cpp
@@ -61,29 +61,36 @@ void gate_init(GateKeeper_Private& client)
     DS_PASSERT(size == 20);
     DS::Uuid uuid;
     DS::RecvBuffer(client.m_sock, uuid.m_bytes, sizeof(uuid.m_bytes));
+    
+    /* Reply header */
+    client.m_buffer.truncate();
+    client.m_buffer.write<uint8_t>(DS::e_ServToCliEncrypt);
 
-    /* Establish encryption */
+    /* Establish encryption, and write reply body */
     uint8_t msgId = DS::RecvValue<uint8_t>(client.m_sock);
     DS_PASSERT(msgId == DS::e_CliToServConnect);
     uint8_t msgSize = DS::RecvValue<uint8_t>(client.m_sock);
-    DS_PASSERT(msgSize == 66);
+    if (msgSize == 2) { // no seed... client wishes unencrypted connection (that's okay, nobody else can "fake" us as nobody has the private key, so if the client actually wants encryption it will only work with the correct peer)
+        client.m_buffer.write<uint8_t>(2); // reply with an empty seed as well
+    }
+    else {
+        uint8_t Y[64];
+        DS_PASSERT(msgSize == 66);
+        DS::RecvBuffer(client.m_sock, Y, 64);
+        BYTE_SWAP_BUFFER(Y, 64);
 
-    uint8_t Y[64];
-    DS::RecvBuffer(client.m_sock, Y, 64);
-    BYTE_SWAP_BUFFER(Y, 64);
+        uint8_t serverSeed[7];
+        uint8_t sharedKey[7];
+        DS::CryptEstablish(serverSeed, sharedKey, DS::Settings::CryptKey(DS::e_KeyGate_N),
+                        DS::Settings::CryptKey(DS::e_KeyGate_K), Y);
+        client.m_crypt = DS::CryptStateInit(sharedKey, 7);
 
-    uint8_t serverSeed[7];
-    uint8_t sharedKey[7];
-    DS::CryptEstablish(serverSeed, sharedKey, DS::Settings::CryptKey(DS::e_KeyGate_N),
-                       DS::Settings::CryptKey(DS::e_KeyGate_K), Y);
-
-    client.m_buffer.truncate();
-    client.m_buffer.write<uint8_t>(DS::e_ServToCliEncrypt);
-    client.m_buffer.write<uint8_t>(9);
-    client.m_buffer.writeBytes(serverSeed, 7);
+        client.m_buffer.write<uint8_t>(9);
+        client.m_buffer.writeBytes(serverSeed, 7);
+    }
+    
+    /* send reply */
     DS::SendBuffer(client.m_sock, client.m_buffer.buffer(), client.m_buffer.size());
-
-    client.m_crypt = DS::CryptStateInit(sharedKey, 7);
 }
 
 void cb_ping(GateKeeper_Private& client)

--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -111,6 +111,7 @@ void DS::CryptEstablish(uint8_t* seed, uint8_t* key, const uint8_t* N,
     BN_bin2bn(reinterpret_cast<const unsigned char*>(Y), 64, bn_Y);
     BN_bin2bn(reinterpret_cast<const unsigned char*>(N), 64, bn_N);
     BN_bin2bn(reinterpret_cast<const unsigned char*>(K), 64, bn_K);
+    DS_PASSERT(!BN_is_zero(bn_N));
     BN_mod_exp(bn_seed, bn_Y, bn_K, bn_N, ctx);
 
     /* Apply server seed for establishing crypt state with client */
@@ -147,6 +148,7 @@ DS::CryptState DS::CryptStateInit(const uint8_t* key, size_t size)
 
 void DS::CryptStateFree(DS::CryptState state)
 {
+    if (state == NULL) return;
     CryptState_Private* statep = reinterpret_cast<CryptState_Private*>(state);
     if (statep) {
         pthread_mutex_destroy(&statep->m_mutex);
@@ -174,7 +176,9 @@ void DS::CryptSendBuffer(const DS::SocketHandle sock, DS::CryptState crypt,
 #endif
 
     CryptState_Private* statep = reinterpret_cast<CryptState_Private*>(crypt);
-    if (size > 4096) {
+    if (!statep) {
+        DS::SendBuffer(sock, buffer, size);
+    } else if (size > 4096) {
         unsigned char* cryptbuf = new unsigned char[size];
         pthread_mutex_lock(&statep->m_mutex);
         RC4(&statep->m_writeKey, size, reinterpret_cast<const unsigned char*>(buffer), cryptbuf);
@@ -194,7 +198,9 @@ void DS::CryptRecvBuffer(const DS::SocketHandle sock, DS::CryptState crypt,
                          void* buffer, size_t size)
 {
     CryptState_Private* statep = reinterpret_cast<CryptState_Private*>(crypt);
-    if (size > 4096) {
+    if (!statep) {
+        DS::RecvBuffer(sock, buffer, size);
+    } else if (size > 4096) {
         unsigned char* cryptbuf = new unsigned char[size];
         DS::RecvBuffer(sock, cryptbuf, size);
         RC4(&statep->m_readKey, size, cryptbuf, reinterpret_cast<unsigned char*>(buffer));

--- a/NetIO/CryptIO.h
+++ b/NetIO/CryptIO.h
@@ -24,8 +24,8 @@
 
 #define BYTE_SWAP_BUFFER(buffer, size) \
     { \
-        for (size_t i=0; i<(size/2); ++i) \
-            std::swap(buffer[i], buffer[size-1-i]); \
+        for (size_t i=0; i<((size)/2); ++i) \
+            std::swap(buffer[i], buffer[(size)-1-i]); \
     }
 
 namespace DS


### PR DESCRIPTION
When the client sends an empty seed in Cli2SrvConnect, reply with an empty seed in Srv2CliEncrypt, and don't use encryption for that connection.

The bignum in Cli2SrvConnect never was really guaranteed to have size 64. The Srv2CliEncrypt change _is_ a protocol change, but only used in the otherwise uncommon (or even impossible) case of a 0 client seed. So this is compatible. The corresponding pull request for CWE is on its way.
