### PR TITLE
Unload avatars when a client crashes.

### DIFF
--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -134,6 +134,34 @@ void dm_propagate_to(GameHost_Private* host, MOUL::NetMessage* msg,
 
 void dm_game_disconnect(GameHost_Private* host, Game_ClientMessage* msg)
 {
+    // Unload the avatar clone if the client committed hara-kiri
+    if (msg->m_client->m_isLoaded && !msg->m_client->m_clientKey.isNull())
+    {
+        MOUL::LoadCloneMsg* cloneMsg = MOUL::LoadCloneMsg::Create();
+        cloneMsg->m_bcastFlags = MOUL::Message::e_NetPropagate
+                               | MOUL::Message::e_LocalPropagate;
+        cloneMsg->m_receivers.push_back(MOUL::Key::NetClientMgrKey);
+        cloneMsg->m_cloneKey = msg->m_client->m_clientKey;
+        cloneMsg->m_requestorKey = MOUL::Key::AvatarMgrKey;
+        cloneMsg->m_userData = 0;
+        cloneMsg->m_originPlayerId = msg->m_client->m_clientInfo.m_PlayerId;
+        cloneMsg->m_validMsg = true;
+        cloneMsg->m_isLoading = false;
+        
+        MOUL::NetMsgLoadClone* netMsg = MOUL::NetMsgLoadClone::Create();
+        netMsg->m_contentFlags = MOUL::NetMessage::e_HasTimeSent
+                               | MOUL::NetMessage::e_NeedsReliableSend;
+        netMsg->m_timestamp.setNow();
+        netMsg->m_isPlayer = true;
+        netMsg->m_isLoading = false;
+        netMsg->m_isInitialState = false;
+        netMsg->m_message = cloneMsg;
+        netMsg->m_object = msg->m_client->m_clientKey;
+        
+        dm_propagate(host, netMsg, msg->m_client->m_clientInfo.m_PlayerId);
+        netMsg->unref();
+    }
+    
     MOUL::NetMsgMemberUpdate* memberMsg = MOUL::NetMsgMemberUpdate::Create();
     memberMsg->m_contentFlags = MOUL::NetMessage::e_HasTimeSent
                               | MOUL::NetMessage::e_IsSystemMessage
@@ -463,6 +491,20 @@ void dm_send_members(GameHost_Private* host, GameClient_Private* client)
     cloneMsg->unref();
 }
 
+void dm_load_clone(GameHost_Private* host, GameClient_Private* client, MOUL::NetMsgLoadClone* netmsg)
+{
+    MOUL::LoadCloneMsg* msg = netmsg->m_message->Cast<MOUL::LoadCloneMsg>();
+    if (msg->makeSafeForNet())
+    {
+        pthread_mutex_lock(&host->m_clientMutex);
+        client->m_clientKey = netmsg->m_object;
+        if (netmsg->m_isPlayer)
+            client->m_isLoaded = netmsg->m_isLoading;
+        pthread_mutex_unlock(&host->m_clientMutex);
+        dm_propagate(host, netmsg, client->m_clientInfo.m_PlayerId);
+    }
+}
+
 void dm_game_message(GameHost_Private* host, Game_PropagateMessage* msg)
 {
     DS::BlobStream stream(msg->m_message);
@@ -533,10 +575,7 @@ void dm_game_message(GameHost_Private* host, Game_PropagateMessage* msg)
             //TODO: Filter messages by client's requested relevance regions
             break;
         case MOUL::ID_NetMsgLoadClone:
-            pthread_mutex_lock(&host->m_clientMutex);
-            msg->m_client->m_clientKey = netmsg->Cast<MOUL::NetMsgLoadClone>()->m_object;
-            pthread_mutex_unlock(&host->m_clientMutex);
-            dm_propagate(host, netmsg, msg->m_client->m_clientInfo.m_PlayerId);
+            dm_load_clone(host, msg->m_client, netmsg->Cast<MOUL::NetMsgLoadClone>());
             break;
         case MOUL::ID_NetMsgPlayerPage:
             //TODO: Whatever the client is expecting us to do

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -181,6 +181,7 @@ void* wk_gameWorker(void* sockp)
     client.m_sock = reinterpret_cast<DS::SocketHandle>(sockp);
     client.m_host = 0;
     client.m_crypt = 0;
+    client.m_isLoaded = false;
 
     try {
         game_client_init(client);

--- a/GameServ/GameServer_Private.h
+++ b/GameServ/GameServer_Private.h
@@ -50,6 +50,7 @@ struct GameClient_Private : public AuthClient_Private
     MOUL::ClientGuid m_clientInfo;
     MOUL::Uoid m_clientKey;
     sdlnamemap_t m_states;
+    bool m_isLoaded;
 };
 
 struct GameHost_Private


### PR DESCRIPTION
We now keep track of the m_isLoaded state given to us by the client. If a client disconnects and the client still has a clone in the age, we send the unload message ourselves to clean up behind the crash.
