### PR TITLE
Add merging between vault and gameserver blobs

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -16,6 +16,7 @@
  ******************************************************************************/
 
 #include "AuthServer_Private.h"
+#include "GameServ/GameServer.h"
 #include "encodings.h"
 #include "settings.h"
 #include "errors.h"
@@ -751,6 +752,32 @@ void* dm_authDaemon(void*)
             case e_VaultUpdateNode:
                 {
                     Auth_NodeInfo* info = reinterpret_cast<Auth_NodeInfo*>(msg.m_payload);
+                    if (!info->m_revision.isNull() && info->m_node.m_NodeType == DS::Vault::e_NodeSDL) {
+                        // This is an SDL update. It needs to be passed off to the gameserver
+                        PostgresStrings<1> parms;
+                        parms.set(0, info->m_node.m_NodeIdx);
+                        PGresult* result = PQexecParams(s_postgres,
+                                                        "SELECT \"idx\" FROM game.\"Servers\" WHERE \"SdlIdx\"=$1",
+                                                        1, 0, parms.m_values, 0, 0, 0);
+                        if (PQresultStatus(result) != PGRES_TUPLES_OK) {
+                            fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
+                                    __FILE__, __LINE__, PQerrorMessage(s_postgres));
+                            PQclear(result);
+                            SEND_REPLY(info, DS::e_NetInternalError);
+                            break;
+                        }
+                        if (PQntuples(result) != 0) {
+                            uint32_t ageMcpId = strtoul(PQgetvalue(result, 0, 0), 0, 10);
+                            PQclear(result);
+                            if(DS::GameServer_UpdateVaultSDL(info->m_node, ageMcpId)) {
+                                SEND_REPLY(info, DS::e_NetSuccess);
+                                break;
+                            }
+                        }
+                    }
+                    if(info->m_revision.isNull()) {
+                        info->m_revision = gen_uuid();
+                    }
                     if (v_update_node(info->m_node)) {
                         // Broadcast the change
                         dm_auth_bcast_node(info->m_node.m_NodeIdx, info->m_revision);

--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -318,6 +318,15 @@ void dm_read_sdl(GameHost_Private* host, GameClient_Private* client,
 #endif
     if (state->m_object.m_name == "AgeSDLHook") {
         host->m_vaultState.add(update);
+        Auth_NodeInfo sdlNode;
+        AuthClient_Private fakeClient;
+        sdlNode.m_client = &fakeClient;
+        sdlNode.m_node.set_NodeIdx(host->m_sdlIdx);
+        sdlNode.m_node.set_Blob_1(host->m_vaultState.toBlob());
+        sdlNode.m_revision = DS::Uuid();
+        s_authChannel.putMessage(e_VaultUpdateNode, reinterpret_cast<void*>(&sdlNode));
+        if (fakeClient.m_channel.getMessage().m_messageType != DS::e_NetSuccess)
+            fprintf(stderr, "[Game] Error writing SDL node back to vault\n");
     } else if (state->m_isAvatar) {
         // TODO: Kick the cheater. Ignoring state updates can be dangerous...
         if (client->m_clientInfo.m_PlayerId != state->m_object.m_clonePlayerId) {
@@ -611,6 +620,52 @@ void dm_game_message(GameHost_Private* host, Game_PropagateMessage* msg)
     SEND_REPLY(msg, DS::e_NetSuccess);
 }
 
+void dm_sdl_update(GameHost_Private* host, Game_SdlMessage* msg) {
+    SDL::State vaultState = SDL::State::FromBlob(msg->m_node.m_Blob_1);
+    host->m_vaultState.merge(vaultState);
+    msg->m_node.m_Blob_1 = host->m_vaultState.toBlob();
+
+    Auth_NodeInfo sdlNode;
+    AuthClient_Private fakeClient;
+    sdlNode.m_client = &fakeClient;
+    sdlNode.m_node = msg->m_node;
+    sdlNode.m_revision = DS::Uuid();
+    s_authChannel.putMessage(e_VaultUpdateNode, reinterpret_cast<void*>(&sdlNode));
+    if (fakeClient.m_channel.getMessage().m_messageType != DS::e_NetSuccess)
+        fprintf(stderr, "[Game] Error writing SDL node back to vault\n");
+
+    Game_AgeInfo info = s_ages[host->m_ageFilename];
+
+    MOUL::NetMsgSDLStateBCast* bcast = MOUL::NetMsgSDLStateBCast::Create(); //MOUL::Factory::Create(MOUL::ID_NetMsgSDLStateBCast);
+    bcast->m_contentFlags = MOUL::NetMessage::e_HasTimeSent
+                            | MOUL::NetMessage::e_NeedsReliableSend;
+    bcast->m_timestamp.setNow();
+    bcast->m_isInitial = true;
+    bcast->m_persistOnServer = true;
+    bcast->m_isAvatar = false;
+    bcast->m_object.m_location = MOUL::Location::Make(info.m_seqPrefix, -2, MOUL::Location::e_BuiltIn);
+    bcast->m_object.m_name = "AgeSDLHook";
+    bcast->m_object.m_type = 1;  // SceneObject
+    bcast->m_object.m_id = 1;
+    bcast->m_sdlBlob = msg->m_node.m_Blob_1;
+    
+    pthread_mutex_lock(&host->m_clientMutex);
+    for (auto client_iter = host->m_clients.begin(); client_iter != host->m_clients.end(); ++client_iter) {
+        try {
+            DM_WRITEMSG(host, bcast);
+            DS::CryptSendBuffer(client_iter->second->m_sock, client_iter->second->m_crypt,
+                                host->m_buffer.buffer(), host->m_buffer.size());
+        } catch (DS::SockHup) {
+            // This is handled below too, but we don't want to skip the rest
+                        // of the client list if one hung up
+        }
+    }
+    pthread_mutex_unlock(&host->m_clientMutex);
+
+    delete bcast;
+    delete msg;
+}
+
 void* dm_gameHost(void* hostp)
 {
     GameHost_Private* host = reinterpret_cast<GameHost_Private*>(hostp);
@@ -630,6 +685,9 @@ void* dm_gameHost(void* hostp)
                 break;
             case e_GamePropagate:
                 dm_game_message(host, reinterpret_cast<Game_PropagateMessage*>(msg.m_payload));
+                break;
+            case e_GameSdlUpdate:
+                dm_sdl_update(host, reinterpret_cast<Game_SdlMessage*>(msg.m_payload));
                 break;
             default:
                 /* Invalid message...  This shouldn't happen */

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -352,6 +352,23 @@ void DS::GameServer_Shutdown()
     pthread_mutex_destroy(&s_gameHostMutex);
 }
 
+bool DS::GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId)
+{
+    pthread_mutex_lock(&s_gameHostMutex);
+    hostmap_t::iterator host_iter = s_gameHosts.find(ageMcpId);
+    GameHost_Private* host = 0;
+    if (host_iter != s_gameHosts.end())
+        host = host_iter->second;
+    pthread_mutex_unlock(&s_gameHostMutex);
+    if (host) {
+        Game_SdlMessage* msg = new Game_SdlMessage;
+        msg->m_node = node;
+        host->m_channel.putMessage(e_GameSdlUpdate, msg);
+        return true;
+    }
+    return false;
+}
+
 void DS::GameServer_DisplayClients()
 {
     pthread_mutex_lock(&s_gameHostMutex);

--- a/GameServ/GameServer.h
+++ b/GameServ/GameServer.h
@@ -23,9 +23,15 @@
 
 namespace DS
 {
+    namespace Vault {
+        class Node;
+    }
+
     void GameServer_Init();
     void GameServer_Add(SocketHandle client);
     void GameServer_Shutdown();
+
+    bool GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId);
 
     void GameServer_DisplayClients();
 }

--- a/GameServ/GameServer_Private.h
+++ b/GameServ/GameServer_Private.h
@@ -95,6 +95,7 @@ extern agemap_t s_ages;
 enum GameHostMessages
 {
     e_GameShutdown, e_GameDisconnect, e_GameJoinAge, e_GamePropagate,
+    e_GameSdlUpdate,
 };
 
 struct Game_ClientMessage
@@ -106,6 +107,11 @@ struct Game_PropagateMessage : public Game_ClientMessage
 {
     uint32_t m_messageType;
     DS::Blob m_message;
+};
+
+struct Game_SdlMessage
+{
+    DS::Vault::Node m_node;
 };
 
 GameHost_Private* start_game_host(uint32_t ageMcpId);

--- a/SDL/StateInfo.cpp
+++ b/SDL/StateInfo.cpp
@@ -384,6 +384,8 @@ void SDL::Variable::read(DS::Stream* stream)
     } else {
         if (m_data->m_flags & e_HasTimeStamp)
             m_data->m_timestamp.read(stream);
+        if (m_data->m_timestamp.isNull())
+            m_data->m_timestamp.setNow();
 
         if (!(m_data->m_flags & e_SameAsDefault)) {
             if (m_data->m_desc->m_size == -1) {
@@ -850,6 +852,18 @@ void SDL::State::add(const SDL::State& state)
     DS_DASSERT(state.m_data->m_desc == m_data->m_desc);
     for (size_t i=0; i<m_data->m_vars.size(); ++i) {
         if (state.m_data->m_vars[i].data()->m_flags & Variable::e_XIsDirty)
+            m_data->m_vars[i] = state.m_data->m_vars[i];
+    }
+}
+
+void SDL::State::merge(const SDL::State& state)
+{
+    if (!m_data)
+        return;
+
+    DS_DASSERT(state.m_data->m_desc == m_data->m_desc);
+    for (size_t i=0; i < m_data->m_vars.size(); ++i) {
+        if (state.m_data->m_vars[i].data()->m_timestamp > m_data->m_vars[i].data()->m_timestamp)
             m_data->m_vars[i] = state.m_data->m_vars[i];
     }
 }

--- a/SDL/StateInfo.h
+++ b/SDL/StateInfo.h
@@ -181,6 +181,7 @@ namespace SDL
         void read(DS::Stream* stream);
         void write(DS::Stream* stream) const;
         void add(const State& state);
+        void merge(const State& state);
 
 #ifdef DEBUG
         void debug();

--- a/Types/UnifiedTime.h
+++ b/Types/UnifiedTime.h
@@ -39,6 +39,17 @@ namespace DS
         }
         bool operator!=(const UnifiedTime& other) const { return !operator==(other); }
 
+        bool operator>(const UnifiedTime& other) const
+        {
+            if (m_secs > other.m_secs) {
+                return true;
+            } else if (m_secs == other.m_secs) {
+                return m_micros > other.m_micros;
+            } else {
+                return false;
+            }
+        }
+
         void setNow();
 
     public:


### PR DESCRIPTION
If a vault update for a running server is received, that update is pushed through the gameserver.

Unfortunately, the client does not send field timestamps in the vault SDL, so the best we can do is replace our gameserver blob with the pushed SDL. This is somewhat addressed by pushing to the vault on every update, but there are still potential race conditions. I don't think any of the existing moula scripts will hit them, though.

The code does support timestamp-based merging, if anyone managers to get the clients to write timestamps into the vault SDL blobs.
