### PR TITLE
Current Population Tracking

### DIFF
--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -160,7 +160,7 @@ struct Auth_PubAgeRequest : public Auth_ClientMessage
 
         DS::Uuid m_instance;
         DS::String m_instancename, m_username, m_description;
-        uint32_t m_sequence, m_language, m_population;
+        uint32_t m_sequence, m_language, m_curPopulation, m_population;
     };
 
     DS::String m_agename;

--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -734,8 +734,8 @@ void cb_getPublicAges(AuthServer_Private& client)
 
             client.m_buffer.write<uint32_t>(msg.m_ages[i].m_sequence);
             client.m_buffer.write<uint32_t>(msg.m_ages[i].m_language);
-            client.m_buffer.write<uint32_t>(0);  // TODO: Owner population
             client.m_buffer.write<uint32_t>(msg.m_ages[i].m_population);
+            client.m_buffer.write<uint32_t>(msg.m_ages[i].m_curPopulation);
         }
     }
 

--- a/AuthServ/AuthVault.cpp
+++ b/AuthServ/AuthVault.cpp
@@ -519,8 +519,8 @@ v_create_age(const AuthServer_AgeInfo& age, uint32_t flags)
         PGresult* result = PQexecParams(s_postgres,
                 "INSERT INTO game.\"PublicAges\""
                 "    (\"AgeUuid\", \"AgeFilename\", \"AgeInstName\", \"AgeUserName\","
-                "     \"AgeDesc\", \"SeqNumber\", \"Language\", \"Population\")"
-                "    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                "     \"AgeDesc\", \"SeqNumber\", \"Language\", \"CurrentPopulation\", \"Population\")"
+                "    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)",
                 8, 0, parms.m_values, 0, 0, 0);
         if (PQresultStatus(result) != PGRES_COMMAND_OK) {
             fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -385,3 +385,17 @@ void DS::GameServer_DisplayClients()
     }
     pthread_mutex_unlock(&s_gameHostMutex);
 }
+
+uint32_t DS::GameServer_GetNumClients(Uuid instance)
+{
+    uint32_t numClients = 0;
+    pthread_mutex_lock(&s_gameHostMutex);
+    for (auto it = s_gameHosts.begin(); it != s_gameHosts.end(); ++it) {
+        if (it->second->m_instanceId == instance) {
+            numClients = it->second->m_clients.size();
+            break;
+        }
+    }
+    pthread_mutex_unlock(&s_gameHostMutex);
+    return numClients;
+}

--- a/GameServ/GameServer.h
+++ b/GameServ/GameServer.h
@@ -19,6 +19,7 @@
 #define _DS_GAMESERVER_H
 
 #include "NetIO/SockIO.h"
+#include "Types/Uuid.h"
 #include <exception>
 
 namespace DS
@@ -34,6 +35,7 @@ namespace DS
     bool GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId);
 
     void GameServer_DisplayClients();
+    uint32_t GameServer_GetNumClients(Uuid instance);
 }
 
 #endif

--- a/db/dbinit.sql
+++ b/db/dbinit.sql
@@ -156,6 +156,7 @@ CREATE TABLE "PublicAges" (
     "AgeDesc" character varying(1024) NOT NULL,
     "SeqNumber" integer NOT NULL,
     "Language" integer NOT NULL,
+    "CurrentPopulation" integer NOT NULL,
     "Population" integer NOT NULL
 );
 ALTER TABLE game."PublicAges" OWNER TO dirtsand;


### PR DESCRIPTION
Fixes #37 -- add a column for Current Population to the public ages table and update it appropriately on client joins/leaves. Also, insert the correct population on creation if an instance of the age is running.
