### PR TITLE
Catch all exceptions when reading a net msg

### DIFF
--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -621,6 +621,11 @@ void dm_game_message(GameHost_Private* host, Game_PropagateMessage* msg)
                 ex.m_file, ex.m_line, ex.m_cond);
         SEND_REPLY(msg, DS::e_NetInternalError);
         return;
+    } catch (std::exception ex) {
+        fprintf(stderr, "[Game] Unknown exception reading message: %s\n",
+                ex.what());
+        SEND_REPLY(msg, DS::e_NetInternalError);
+        return;
     }
 #ifdef DEBUG
     if (!stream.atEof()) {


### PR DESCRIPTION
This quick hack prevents the server from being taken down completely when a message causes an exception other than a DS Assert to be thrown.
