### PR TITLE
Change PublicAges to a listing of AgeInfo nodes

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -398,9 +398,15 @@ void dm_auth_createPlayer(Auth_PlayerCreate* msg)
     PQclear(result);
 
     AuthServer_Private* client = reinterpret_cast<AuthServer_Private*>(msg->m_client);
-    msg->m_player.m_playerId = std::get<0>(v_create_player(client->m_acctUuid, msg->m_player));
+    std::tuple<uint32_t, uint32_t, uint32_t> player =
+        v_create_player(client->m_acctUuid, msg->m_player);
+    msg->m_player.m_playerId = std::get<0>(player);
     if (msg->m_player.m_playerId == 0)
         SEND_REPLY(msg, DS::e_NetInternalError);
+
+    // Tell neighborhood about its new member
+    v_ref_node(std::get<2>(player), std::get<1>(player), std::get<0>(player));
+    dm_auth_bcast_ref({std::get<2>(player), std::get<1>(player), std::get<0>(player), 0});
 
     PostgresStrings<5> iparms;
     iparms.set(0, client->m_acctUuid.toString());
@@ -637,143 +643,54 @@ void dm_auth_findAge(Auth_GameAge* msg)
 
 void dm_auth_get_public(Auth_PubAgeRequest* msg)
 {
-    PostgresStrings<1> parms;
-    parms.set(0, msg->m_agename);
-    PGresult* result = PQexecParams(s_postgres,
-                                    "SELECT idx, \"AgeUuid\", \"AgeInstName\", \"AgeUserName\", \"AgeDesc\", \"SeqNumber\", \"Language\", \"CurrentPopulation\", \"Population\" FROM game.\"PublicAges\""
-                                    "    WHERE \"AgeFilename\"=$1",
-                                    1, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_TUPLES_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(s_postgres));
-        PQclear(result);
+    if (v_find_public_ages(msg->m_agename, msg->m_ages))
+        SEND_REPLY(msg, DS::e_NetSuccess);
+    else
         SEND_REPLY(msg, DS::e_NetInternalError);
-        return;
-    }
-    for (int i = 0; i < PQntuples(result); i++) {
-        Auth_PubAgeRequest::NetAgeInfo ai;
-        ai.m_instance = DS::Uuid(PQgetvalue(result, i, 1));
-        ai.m_instancename = PQgetvalue(result, i, 2);
-        ai.m_username = PQgetvalue(result, i, 3);
-        ai.m_description = PQgetvalue(result, i, 4);
-        ai.m_sequence = strtoul(PQgetvalue(result, i, 5), 0, 10);
-        ai.m_language = strtoul(PQgetvalue(result, i, 6), 0, 10);
-        ai.m_curPopulation = strtoul(PQgetvalue(result, i, 7), 0, 10);
-        ai.m_population = strtoul(PQgetvalue(result, i, 8), 0, 10);
-        msg->m_ages.push_back(ai);
-    }
-    PQclear(result);
-    SEND_REPLY(msg, DS::e_NetSuccess);
 }
 
 uint32_t dm_auth_set_public(uint32_t nodeid)
 {
-    PostgresStrings<8> parms;
-    parms.set(0, nodeid);
-    parms.set(1, DS::Vault::e_NodeAgeInfo);
-    PGresult* result = PQexecParams(s_postgres,
-                                    "SELECT \"Uuid_1\", \"String64_2\", \"String64_3\", \"String64_4\", \"Text_1\", \"Int32_1\", \"Int32_3\" FROM vault.\"Nodes\""
-                                    "    WHERE idx=$1 AND \"NodeType\"=$2",
-                                    2, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_TUPLES_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(s_postgres));
-        PQclear(result);
-        return DS::e_NetInternalError;
-    }
-    if (PQntuples(result) == 0) {
-        // the requested age wasn't public, so we throw an error
-        PQclear(result);
-        return DS::e_NetInvalidParameter;
-    }
-    parms.set(0, PQgetvalue(result, 0, 0));
-    parms.set(1, PQgetvalue(result, 0, 1));
-    parms.set(2, PQgetvalue(result, 0, 2));
-    parms.set(3, PQgetvalue(result, 0, 3));
-    parms.set(4, PQgetvalue(result, 0, 4));
-    parms.set(5, PQgetvalue(result, 0, 5));
-    parms.set(6, PQgetvalue(result, 0, 6));
-    parms.set(7, DS::GameServer_GetNumClients(DS::Uuid(PQgetvalue(result, 0, 0))));
-
-    PQclear(result);
-    result = PQexecParams(s_postgres,
-                          "INSERT INTO game.\"PublicAges\" (\"AgeUuid\", \"AgeFilename\", \"AgeInstName\", \"AgeUserName\", \"AgeDesc\", \"SeqNumber\", \"Language\", \"CurrentPopulation\", \"Population\")"
-                          "    VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, 0 )",
-                          8, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(s_postgres));
-        PQclear(result);
-        return DS::e_NetInternalError;
-    }
-
-    parms.set(0, DS::Vault::e_NodeAgeInfo);
+    PostgresStrings<3> parms;
+    parms.set(0, (uint32_t)time(0));
     parms.set(1, nodeid);
-    result = PQexecParams(s_postgres,
-                          "UPDATE vault.\"Nodes\" SET"
-                          "    \"Int32_2\"=1"
-                          "    WHERE \"NodeType\"=$1 AND idx=$2",
-                          2, 0, parms.m_values, 0, 0, 0);
+    parms.set(2, DS::Vault::e_NodeAgeInfo);
+    PGresult* result = PQexecParams(s_postgres,"UPDATE vault.\"Nodes\" SET"
+                       "    \"ModifyTime\"=$1, \"Int32_2\"=1 WHERE idx=$2"
+                       "     AND \"NodeType\"=$3",
+                       3, 0, parms.m_values, 0, 0, 0);
     if (PQresultStatus(result) != PGRES_COMMAND_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
-      // This doesn't block continuing...
+        PQclear(result);
+        return DS::e_NetInternalError;
     } else {
         dm_auth_bcast_node(nodeid, gen_uuid());
+        PQclear(result);
+        return DS::e_NetSuccess;
     }
-
-    return DS::e_NetSuccess;
 }
 
 uint32_t dm_auth_set_private(uint32_t nodeid)
 {
-    PostgresStrings<4> parms;
-    parms.set(0, nodeid);
+    PostgresStrings<3> parms;
+    parms.set(0, (uint32_t)time(0));
     parms.set(1, DS::Vault::e_NodeAgeInfo);
-    PGresult* result = PQexecParams(s_postgres,
-                                    "SELECT \"Uuid_1\" FROM vault.\"Nodes\" WHERE idx=$1 AND \"NodeType\"=$2",
-                                    2, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_TUPLES_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(s_postgres));
-        PQclear(result);
-        return DS::e_NetInternalError;
-    }
-    if (PQntuples(result) == 0) {
-        fprintf(stderr, "%s:%d:\n    No such ageinfo node: %d\n",
-                __FILE__, __LINE__, nodeid);
-        // the requested age doesn't exist
-        PQclear(result);
-        return DS::e_NetInvalidParameter;
-    }
-
-    parms.set(0, PQgetvalue(result, 0, 0));
-    result = PQexecParams(s_postgres,
-                          "DELETE FROM game.\"PublicAges\" WHERE \"AgeUuid\"=$1",
-                          1, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres DELETE error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(s_postgres));
-        PQclear(result);
-        return DS::e_NetInternalError;
-    }
-
-    parms.set(0, DS::Vault::e_NodeAgeInfo);
-    parms.set(1, nodeid);
-    result = PQexecParams(s_postgres,
-                          "UPDATE vault.\"Nodes\" SET"
-                          "    \"Int32_2\"=0"
-                          "    WHERE \"NodeType\"=$1 AND idx=$2",
-                          2, 0, parms.m_values, 0, 0, 0);
+    parms.set(2, nodeid);
+    PGresult* result = PQexecParams(s_postgres, "UPDATE vault.\"Nodes\" SET"
+                       "    \"Int32_2\"=0, \"ModifyTime\"=$1"
+                       "    WHERE \"NodeType\"=$2 AND idx=$3",
+                       3, 0, parms.m_values, 0, 0, 0);
     if (PQresultStatus(result) != PGRES_COMMAND_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                  __FILE__, __LINE__, PQerrorMessage(s_postgres));
-         // This doesn't block continuing...
+        PQclear(result);
+        return DS::e_NetInternalError;
     } else {
         dm_auth_bcast_node(nodeid, gen_uuid());
+        PQclear(result);
+        return DS::e_NetSuccess;
     }
-
-    return DS::e_NetSuccess;
 }
 
 void dm_auth_set_pub_priv(Auth_SetPublic* msg)
@@ -819,19 +736,6 @@ void dm_authDaemon()
         // This doesn't block continuing...
         DS_DASSERT(false);
     }
-
-    // Mark all public ages as having a current population of ZERO
-    result = PQexec(s_postgres,
-                              "UPDATE game.\"PublicAges\" SET"
-                              "    \"CurrentPopulation\" = 0");
-    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(s_postgres));
-        // This doesn't block continuing...
-        PQclear(result);
-        DS_DASSERT(false);
-    } else
-        PQclear(result);
 
     for ( ;; ) {
         DS::FifoMessage msg = s_authChannel.getMessage();

--- a/AuthServ/AuthServer_Private.h
+++ b/AuthServ/AuthServer_Private.h
@@ -118,7 +118,7 @@ enum AgeFlags
 std::tuple<uint32_t, uint32_t>
 v_create_age(AuthServer_AgeInfo age, uint32_t flags);
 
-std::tuple<uint32_t, uint32_t>
+std::tuple<uint32_t, uint32_t, uint32_t> // playerId, playerInfoId, hoodAgeOwnersFolderId
 v_create_player(DS::Uuid accountId, const AuthServer_PlayerInfo& player);
 
 uint32_t v_create_node(const DS::Vault::Node& node);
@@ -129,3 +129,6 @@ bool v_unref_node(uint32_t parentIdx, uint32_t childIdx);
 bool v_fetch_tree(uint32_t nodeId, std::vector<DS::Vault::NodeRef>& refs);
 bool v_find_nodes(const DS::Vault::Node& nodeTemplate, std::vector<uint32_t>& nodes);
 DS::Vault::NodeRef v_send_node(uint32_t nodeId, uint32_t playerId, uint32_t senderId);
+
+uint32_t v_count_age_owners(uint32_t ageInfoId);
+bool v_find_public_ages(const DS::String& ageFilename, std::vector<Auth_PubAgeRequest::NetAgeInfo>& ages);

--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -240,20 +240,6 @@ void dm_game_disconnect(GameHost_Private* host, Game_ClientMessage* msg)
     if (fakeClient.m_channel.getMessage().m_messageType != DS::e_NetSuccess)
         fputs("[Game] Error writing SDL node back to vault\n", stderr);
 
-    // Update public ages table
-    PostgresStrings<1> parms;
-    parms.set(0, host->m_instanceId.toString());
-    PGresult* result = PQexecParams(host->m_postgres,
-                                    "UPDATE game.\"PublicAges\" SET"
-                                    "    \"CurrentPopulation\" = \"CurrentPopulation\" - 1"
-                                    "    WHERE \"AgeUuid\" = $1",
-                                    1, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(host->m_postgres));
-        // This doesn't block continuing...
-    }
-
     // TODO: This should probably respect the age's LingerTime
     //       As it is, there might be a race condition if another player is
     //       joining just as the last player is leaving.
@@ -263,20 +249,6 @@ void dm_game_disconnect(GameHost_Private* host, Game_ClientMessage* msg)
 
 void dm_game_join(GameHost_Private* host, Game_ClientMessage* msg)
 {
-    // Update public ages table
-    PostgresStrings<1> parms;
-    parms.set(0, host->m_instanceId.toString());
-    PGresult* result = PQexecParams(host->m_postgres,
-                                    "UPDATE game.\"PublicAges\" SET"
-                                    "    \"CurrentPopulation\" = \"CurrentPopulation\" + 1"
-                                    "    WHERE \"AgeUuid\" = $1",
-                                    1, 0, parms.m_values, 0, 0, 0);
-    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-        fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
-                __FILE__, __LINE__, PQerrorMessage(host->m_postgres));
-        // This doesn't block continuing...
-    }
-
     // Simplified object ownership...
     // In MOUL, one player owns ALL synched objects
     // We'll call him the "game master"

--- a/db/dbinit.sql
+++ b/db/dbinit.sql
@@ -131,6 +131,7 @@ CREATE TABLE "Nodes" (
     "Blob_2" text
 );
 ALTER TABLE vault."Nodes" OWNER TO dirtsand;
+CREATE INDEX PublicAgeList ON vault."Nodes" ("NodeType", "Int32_2", "String64_2");
 CREATE SEQUENCE "Nodes_idx_seq"
     INCREMENT BY 1
     NO MAXVALUE
@@ -161,29 +162,6 @@ CREATE SEQUENCE "Servers_idx_seq"
 ALTER TABLE game."Servers_idx_seq" OWNER TO dirtsand;
 ALTER SEQUENCE "Servers_idx_seq" OWNED BY "Servers".idx;
 SELECT pg_catalog.setval('"Servers_idx_seq"', 1, false);
-
-CREATE TABLE "PublicAges" (
-    idx integer NOT NULL,
-    "AgeUuid" uuid NOT NULL,
-    "AgeFilename" character varying(64) NOT NULL,
-    "AgeInstName" character varying(64) NOT NULL,
-    "AgeUserName" character varying(64) NOT NULL,
-    "AgeDesc" character varying(1024) NOT NULL,
-    "SeqNumber" integer NOT NULL,
-    "Language" integer NOT NULL,
-    "CurrentPopulation" integer NOT NULL,
-    "Population" integer NOT NULL
-);
-ALTER TABLE game."PublicAges" OWNER TO dirtsand;
-CREATE SEQUENCE "PublicAges_idx_seq"
-    START WITH 1
-    INCREMENT BY 1
-    NO MAXVALUE
-    NO MINVALUE
-    CACHE 1;
-ALTER TABLE game."PublicAges_idx_seq" OWNER TO dirtsand;
-ALTER SEQUENCE "PublicAges_idx_seq" OWNED BY "PublicAges".idx;
-SELECT pg_catalog.setval('"PublicAges_idx_seq"', 1, false);
 
 CREATE SEQUENCE "AgeSeqNumber"
     START WITH 1
@@ -235,13 +213,10 @@ ALTER TABLE ONLY "Nodes"
 
 SET search_path = game, pg_catalog;
 ALTER TABLE "Servers" ALTER COLUMN idx SET DEFAULT nextval('"Servers_idx_seq"'::regclass);
-ALTER TABLE "PublicAges" ALTER COLUMN idx SET DEFAULT nextval('"PublicAges_idx_seq"'::regclass);
 ALTER TABLE "AgeStates" ALTER COLUMN idx SET DEFAULT nextval('"AgeStates_idx_seq"'::regclass);
 
 ALTER TABLE ONLY "Servers"
     ADD CONSTRAINT "Servers_pkey" PRIMARY KEY (idx);
-ALTER TABLE ONLY "PublicAges"
-    ADD CONSTRAINT "PublicAges_pkey" PRIMARY KEY (idx);
 ALTER TABLE ONLY "AgeStates"
     ADD CONSTRAINT "AgeStates_pkey" PRIMARY KEY (idx);
 

--- a/db/functions.sql
+++ b/db/functions.sql
@@ -77,14 +77,12 @@ $BODY$
 SELECT setval('vault."Nodes_idx_seq"', 10001, false);
 SELECT setval('vault."NodeRefs_idx_seq"', 1, false);
 SELECT setval('game."Servers_idx_seq"', 1, false);
-SELECT setval('game."PublicAges_idx_seq"', 1, false);
 SELECT setval('game."AgeSeqNumber"', 1, false);
 SELECT setval('game."AgeStates_idx_seq"', 1, false);
 SELECT setval('auth."Players_idx_seq"', 1, false);
 DELETE FROM vault."Nodes";
 DELETE FROM vault."NodeRefs";
 DELETE FROM game."Servers";
-DELETE FROM game."PublicAges";
 DELETE FROM game."AgeStates";
 DELETE FROM auth."Players";
 $BODY$

--- a/settings.h
+++ b/settings.h
@@ -29,6 +29,10 @@
 #define CLIENT_BRANCH_ID  (1)
 #define CLIENT_PRODUCT_ID "ea489821-6c35-4bd0-9dae-bb17c585e680"
 
+#define HOOD_USER_NAME "DS"
+#define HOOD_INSTANCE_NAME "Neighborhood"
+#define HOOD_POPULATION_THRESHOLD (20)
+
 #define CHUNK_SIZE (0x8000)
 
 namespace DS


### PR DESCRIPTION
A race condition was discovered on the Gehn Shard where duplicate ages could be inserted into the public ages table. Rather than fixing that, I opted to convert it to a giant vault search. This allows us to fix a few issues.
- The total popluation (number of owners) is now correctly reported. This means that player created Neighborhoods will now show up in the Nexus. Fixes #42 
- The current population is now discovered via a search of PlayerInfo nodes. This will prevent weird integer_overflow populations from appearing in the nexus.
- New members of default Neighborhoods are forwarded to clients.
- Fix some PGresult\* leaks in the old code.
- FEATURE: You can now configure the default hood user and instance names in settings.h
