### PR TITLE
Concurrency Improvement

### DIFF
--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -155,7 +155,7 @@ void DS::CryptStateFree(DS::CryptState state)
 }
 
 void DS::CryptSendBuffer(const DS::SocketHandle sock, DS::CryptState crypt,
-                         const void* buffer, size_t size)
+                         const void* buffer, size_t size, SendFlag mode)
 {
 #ifdef DEBUG
     if (s_commdebug) {
@@ -180,14 +180,14 @@ void DS::CryptSendBuffer(const DS::SocketHandle sock, DS::CryptState crypt,
         statep->m_mutex.lock();
         RC4(&statep->m_writeKey, size, reinterpret_cast<const unsigned char*>(buffer), cryptbuf);
         statep->m_mutex.unlock();
-        DS::SendBuffer(sock, cryptbuf, size);
+        DS::SendBuffer(sock, cryptbuf, size, mode);
         delete[] cryptbuf;
     } else {
         unsigned char stack[4096];
         statep->m_mutex.lock();
         RC4(&statep->m_writeKey, size, reinterpret_cast<const unsigned char*>(buffer), stack);
         statep->m_mutex.unlock();
-        DS::SendBuffer(sock, stack, size);
+        DS::SendBuffer(sock, stack, size, mode);
     }
 }
 

--- a/NetIO/CryptIO.h
+++ b/NetIO/CryptIO.h
@@ -53,7 +53,7 @@ namespace DS
     void CryptStateFree(CryptState state);
 
     void CryptSendBuffer(const SocketHandle sock, CryptState crypt,
-                         const void* buffer, size_t size);
+                         const void* buffer, size_t size, SendFlag mode=e_SendBlocking);
     void CryptRecvBuffer(const SocketHandle sock, CryptState crypt,
                          void* buffer, size_t size);
 

--- a/NetIO/SockIO.h
+++ b/NetIO/SockIO.h
@@ -23,6 +23,14 @@
 
 namespace DS
 {
+    enum SendFlag
+    {
+        e_SendBlocking,
+        e_SendNonblocking,
+        e_SendNonblockingRecoverable,
+        e_SendMax
+    };
+
     typedef void* SocketHandle;
 
     SocketHandle BindSocket(const char* address, const char* port);
@@ -34,7 +42,8 @@ namespace DS
     String SockIpAddress(const SocketHandle sock);
     uint32_t GetAddress4(const char* lookup);
 
-    void SendBuffer(const SocketHandle sock, const void* buffer, size_t size);
+    void SendBuffer(const SocketHandle sock, const void* buffer,
+                    size_t size, SendFlag mode=e_SendBlocking);
     void RecvBuffer(const SocketHandle sock, void* buffer, size_t size);
     size_t PeekSize(const SocketHandle sock);
 


### PR DESCRIPTION
This changeset addresses concurrency issues observed during the Gehn Shard Birthday Party. It was observed that the game host thread would get stuck in `dm_propagate` at seemingly random points in time. To address this, I have changed all message broadcasts to be nonblocking. To ensure that clients are not kicked off for simply moving around, I allow for sends to fail if the legacy unreliable send bit is set on the message (this is inverted into a require reliable bit on the net message). I also removed the std::list copy hack from the AuthDaemon and replaced it with nonblocking sends. This is likely the best fix for the problem without a major restructuring of the server.
