### PR TITLE
Move product and neighborhood settings to CMake-based configuration

### DIFF
--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -106,7 +106,7 @@ void cb_register(AuthServer_Private& client)
 
     // Build ID
     uint32_t buildId = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
-    if (buildId && buildId != CLIENT_BUILD_ID) {
+    if (buildId && buildId != DS::Settings::BuildId()) {
         fprintf(stderr, "[Auth] Wrong Build ID from %s: %d\n",
                 DS::SockIpAddress(client.m_sock).c_str(), buildId);
         DS::CloseSock(client.m_sock);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,20 @@
 project(dirtsand)
 cmake_minimum_required(VERSION 2.6)
 
+# Set up Product Identification parameters (NOTE: Should match plClient)
+set(PRODUCT_BRANCH_ID   "1"         CACHE STRING "Branch ID")
+set(PRODUCT_BUILD_ID    "912"       CACHE STRING "Build ID")
+set(PRODUCT_BUILD_TYPE  "50"        CACHE STRING "Build Type")
+set(PRODUCT_UUID        "ea489821-6c35-4bd0-9dae-bb17c585e680"
+                                    CACHE STRING "Product UUID")
+
+set(DS_HOOD_USER_NAME       "DS"
+    CACHE STRING "Default Neighborhood Name")
+set(DS_HOOD_INST_NAME       "Neighborhood"
+    CACHE STRING "Default Neighborhood Instance Name")
+set(DS_HOOD_POP_THRESHOLD   "20"
+    CACHE STRING "Default Neighborhood Max Population")
+
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GCC_VERSION)
@@ -34,6 +48,14 @@ try_compile(HAVE_ATOMIC ${dirtsand_BINARY_DIR}
 if(HAVE_ATOMIC)
     add_definitions(-DHAVE_ATOMIC)
 endif()
+
+add_definitions(-DPRODUCT_BRANCH_ID=${PRODUCT_BRANCH_ID})
+add_definitions(-DPRODUCT_BUILD_ID=${PRODUCT_BUILD_ID})
+add_definitions(-DPRODUCT_BUILD_TYPE=${PRODUCT_BUILD_TYPE})
+add_definitions(-DPRODUCT_UUID="${PRODUCT_UUID}")
+add_definitions(-DHOOD_USER_NAME="${DS_HOOD_USER_NAME}")
+add_definitions(-DHOOD_INST_NAME="${DS_HOOD_INST_NAME}")
+add_definitions(-DHOOD_POP_THRESHOLD=${DS_HOOD_POP_THRESHOLD})
 
 set(PlasMOUL_SOURCES
     PlasMOUL/AgeLinkStruct.cpp

--- a/FileServ/FileServer.cpp
+++ b/FileServ/FileServer.cpp
@@ -97,7 +97,7 @@ void cb_buildId(FileServer_Private& client)
     client.m_buffer.write<uint32_t>(DS::e_NetSuccess);
 
     // Build ID
-    client.m_buffer.write<uint32_t>(CLIENT_BUILD_ID);
+    client.m_buffer.write<uint32_t>(DS::Settings::BuildId());
 
     SEND_REPLY();
 }
@@ -117,7 +117,7 @@ void cb_manifest(FileServer_Private& client)
 
     // Build ID
     uint32_t buildId = DS::RecvValue<uint32_t>(client.m_sock);
-    if (buildId && buildId != CLIENT_BUILD_ID) {
+    if (buildId && buildId != DS::Settings::BuildId()) {
         fprintf(stderr, "[File] Wrong Build ID from %s: %d\n",
                 DS::SockIpAddress(client.m_sock).c_str(), buildId);
         DS::CloseSock(client.m_sock);
@@ -183,7 +183,7 @@ void cb_downloadStart(FileServer_Private& client)
 
     // Build ID
     uint32_t buildId = DS::RecvValue<uint32_t>(client.m_sock);
-    if (buildId && buildId != CLIENT_BUILD_ID) {
+    if (buildId && buildId != DS::Settings::BuildId()) {
         fprintf(stderr, "[File] Wrong Build ID from %s: %d\n",
                 DS::SockIpAddress(client.m_sock).c_str(), buildId);
         DS::CloseSock(client.m_sock);

--- a/dsmain.cpp
+++ b/dsmain.cpp
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
     DS::StartStatusHTTP();
 
     char rl_prompt[32];
-    snprintf(rl_prompt, 32, "ds-%u> ", CLIENT_BUILD_ID);
+    snprintf(rl_prompt, 32, "ds-%u> ", DS::Settings::BuildId());
 
     char* cmdbuf = 0;
     rl_attempted_completion_function = &console_completer;

--- a/settings.cpp
+++ b/settings.cpp
@@ -21,6 +21,43 @@
 #include <vector>
 #include <cstdio>
 
+/* Constants configured via CMake */
+uint32_t DS::Settings::BranchId()
+{
+    return PRODUCT_BRANCH_ID;
+}
+
+uint32_t DS::Settings::BuildId()
+{
+    return PRODUCT_BUILD_ID;
+}
+
+uint32_t DS::Settings::BuildType()
+{
+    return PRODUCT_BUILD_TYPE;
+}
+
+const char* DS::Settings::ProductUuid()
+{
+    return PRODUCT_UUID;
+}
+
+const char* DS::Settings::HoodUserName()
+{
+    return HOOD_USER_NAME;
+}
+
+const char* DS::Settings::HoodInstanceName()
+{
+    return HOOD_INST_NAME;
+}
+
+uint32_t DS::Settings::HoodPopThreshold()
+{
+    return HOOD_POP_THRESHOLD;
+}
+
+
 static struct
 {
     /* Encryption */

--- a/settings.h
+++ b/settings.h
@@ -24,15 +24,6 @@
 #define CRYPT_BASE_GAME (73)
 #define CRYPT_BASE_GATE (4)
 
-#define CLIENT_BUILD_ID   (912)
-#define CLIENT_BUILD_TYPE (50)
-#define CLIENT_BRANCH_ID  (1)
-#define CLIENT_PRODUCT_ID "ea489821-6c35-4bd0-9dae-bb17c585e680"
-
-#define HOOD_USER_NAME "DS"
-#define HOOD_INSTANCE_NAME "Neighborhood"
-#define HOOD_POPULATION_THRESHOLD (20)
-
 #define CHUNK_SIZE (0x8000)
 
 namespace DS
@@ -45,6 +36,18 @@ namespace DS
 
     namespace Settings
     {
+        // Product ID values
+        uint32_t BranchId();
+        uint32_t BuildId();
+        uint32_t BuildType();
+        const char* ProductUuid();
+
+        // Neighborhood Defaults
+        const char* HoodUserName();
+        const char* HoodInstanceName();
+        uint32_t HoodPopThreshold();
+
+        // Encryption keys
         const uint8_t* CryptKey(KeyType key);
         const uint32_t* DroidKey();
 


### PR DESCRIPTION
This matches the change of the same nature on Plasma itself, making per-shard configuration easier without creating a separate branch or maintaining modified files.

I have tested compiling this, but I would like to see at least one shard (e.g. Gehn) use the new system before I actually merge it.
