### PR TITLE
Fix cross-age SDL node updates

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -1088,6 +1088,42 @@ void dm_auth_update_globalSDL(Auth_UpdateGlobalSDL* msg)
     SEND_REPLY(msg, DS::e_NetInvalidParameter);
 }
 
+bool dm_auth_merge_sdl(Auth_NodeInfo* info)
+{
+    // This is an SDL update. It needs to be passed off to the gameserver
+    PostgresStrings<1> parms;
+    parms.set(0, info->m_node.m_NodeIdx);
+    PGresult* result = PQexecParams(s_postgres,
+                                    "SELECT \"idx\" FROM game.\"Servers\" WHERE \"SdlIdx\"=$1",
+                                    1, 0, parms.m_values, 0, 0, 0);
+    if (PQresultStatus(result) != PGRES_TUPLES_OK) {
+        fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
+                __FILE__, __LINE__, PQerrorMessage(s_postgres));
+        PQclear(result);
+        SEND_REPLY(info, DS::e_NetInternalError);
+        return true;
+    }
+    if (PQntuples(result) != 0) {
+        uint32_t ageMcpId = strtoul(PQgetvalue(result, 0, 0), 0, 10);
+        if (DS::GameServer_UpdateVaultSDL(info->m_node, ageMcpId)) {
+            PQclear(result);
+            SEND_REPLY(info, DS::e_NetSuccess);
+            return true;
+        }
+    }
+    PQclear(result);
+
+    // The client submits partial updates, so we need to merge the nodes here :(
+    DS::Vault::Node oldNode = v_fetch_node(info->m_node.m_NodeIdx);
+    SDL::State state = SDL::State::FromBlob(oldNode.m_Blob_1);
+    SDL::State diff = SDL::State::FromBlob(info->m_node.m_Blob_1);
+    state.merge(diff);
+
+    // Pass thru to normal vault node update behavior
+    info->m_node.m_Blob_1 = state.toBlob();
+    return false;
+}
+
 void dm_authDaemon()
 {
     s_postgres = PQconnectdb(DS::String::Format(
@@ -1179,26 +1215,9 @@ void dm_authDaemon()
                 {
                     Auth_NodeInfo* info = reinterpret_cast<Auth_NodeInfo*>(msg.m_payload);
                     if (!info->m_internal && info->m_node.m_NodeType == DS::Vault::e_NodeSDL) {
-                        // This is an SDL update. It needs to be passed off to the gameserver
-                        PostgresStrings<1> parms;
-                        parms.set(0, info->m_node.m_NodeIdx);
-                        PGresult* result = PQexecParams(s_postgres,
-                                                        "SELECT \"idx\" FROM game.\"Servers\" WHERE \"SdlIdx\"=$1",
-                                                        1, 0, parms.m_values, 0, 0, 0);
-                        if (PQresultStatus(result) != PGRES_TUPLES_OK) {
-                            fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
-                                    __FILE__, __LINE__, PQerrorMessage(s_postgres));
-                            PQclear(result);
-                            SEND_REPLY(info, DS::e_NetInternalError);
+                        if (dm_auth_merge_sdl(info)) {
+                            // Handled by the GameServ, so we need to go away.
                             break;
-                        }
-                        if (PQntuples(result) != 0) {
-                            uint32_t ageMcpId = strtoul(PQgetvalue(result, 0, 0), 0, 10);
-                            PQclear(result);
-                            if (DS::GameServer_UpdateVaultSDL(info->m_node, ageMcpId)) {
-                                SEND_REPLY(info, DS::e_NetSuccess);
-                                break;
-                            }
                         }
                     }
                     if (info->m_revision.isNull()) {

--- a/SDL/StateInfo.cpp
+++ b/SDL/StateInfo.cpp
@@ -390,7 +390,6 @@ void SDL::Variable::read(DS::Stream* stream)
             m_data->m_flags |= e_HasTimeStamp;
         }
 
-        m_data->m_flags &= ~e_HasDirtyFlag;
         if (!(m_data->m_flags & e_SameAsDefault)) {
             if (m_data->m_desc->m_size == -1) {
                 size_t count = stream->read<uint32_t>();


### PR DESCRIPTION
When the client sends SDL node updates, it only sends the variables that have changed. We only handled that case in the GameServ--which worked 95% of the time. If the age was not running however, the auth server would blindly save the diff as the new age state. This resulted in, for example, a player's Relto state being thrown away if they picked up a Relto Page in Kadish. This changeset fixes that.

Also, as a bonus, I fixed a potential but highly unlikely `PGresult*` leak.
