### PR TITLE
SDL Descriptors are now case-insensitive

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -30,7 +30,7 @@ DS::MsgChannel s_authChannel;
 PGconn* s_postgres;
 bool s_restrictLogins = false;
 extern uint32_t s_allPlayers;
-std::unordered_map<ST::string, SDL::State, ST::hash> s_globalStates;
+std::unordered_map<ST::string, SDL::State, ST::hash_i, ST::equal_i> s_globalStates;
 
 #define SEND_REPLY(msg, result) \
     msg->m_client->m_channel.putMessage(result)

--- a/SDL/DescriptorDb.h
+++ b/SDL/DescriptorDb.h
@@ -82,7 +82,7 @@ namespace SDL
         ~DescriptorDb() = delete;
 
         typedef std::unordered_map<int, StateDescriptor> versionmap_t;
-        typedef std::unordered_map<ST::string, versionmap_t, ST::hash> descmap_t;
+        typedef std::unordered_map<ST::string, versionmap_t, ST::hash_i, ST::equal_i> descmap_t;
         static descmap_t s_descriptors;
     };
 }


### PR DESCRIPTION
Cyan did so much foolishness with SDL casing that it would just be better to tolerate it. We were having some problems with SpyRoom != spyroom in Gehn.20 :cry:.

Note that Hash and HashI were copied from H-uru/Plasma.
