### PR TITLE
Move all sending operations to client threads

### DIFF
--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -29,6 +29,7 @@ struct AuthClient_Private
     DS::SocketHandle m_sock;
     DS::CryptState m_crypt;
     DS::MsgChannel m_channel;
+    DS::MsgChannel m_broadcast;
 };
 
 struct AuthServer_PlayerInfo

--- a/GameServ/GameServer_Private.h
+++ b/GameServ/GameServer_Private.h
@@ -77,7 +77,6 @@ struct GameHost_Private
     std::mutex m_lockMutex;
     std::mutex m_gmMutex;
     DS::MsgChannel m_channel;
-    DS::BufferStream m_buffer;
 
     PGconn* m_postgres;
     sdlstatemap_t m_states;

--- a/NetIO/CryptIO.h
+++ b/NetIO/CryptIO.h
@@ -53,7 +53,7 @@ namespace DS
     void CryptStateFree(CryptState state);
 
     void CryptSendBuffer(const SocketHandle sock, CryptState crypt,
-                         const void* buffer, size_t size, SendFlag mode=e_SendDefault);
+                         const void* buffer, size_t size);
     void CryptRecvBuffer(const SocketHandle sock, CryptState crypt,
                          void* buffer, size_t size);
 

--- a/NetIO/MsgChannel.cpp
+++ b/NetIO/MsgChannel.cpp
@@ -57,3 +57,9 @@ DS::FifoMessage DS::MsgChannel::getMessage()
     m_queueMutex.unlock();
     return msg;
 }
+
+bool DS::MsgChannel::hasMessage()
+{
+    std::lock_guard<std::mutex> guard(m_queueMutex);
+    return !m_queue.empty();
+}

--- a/NetIO/MsgChannel.cpp
+++ b/NetIO/MsgChannel.cpp
@@ -15,22 +15,20 @@
  * along with dirtsand.  If not, see <http://www.gnu.org/licenses/>.          *
  ******************************************************************************/
 
+#include <sys/eventfd.h>
+#include <unistd.h>
 #include "MsgChannel.h"
 #include "errors.h"
 
 DS::MsgChannel::MsgChannel()
 {
-    int result;
-
-    result = sem_init(&m_semaphore, 0, 0);
-    DS_PASSERT(result == 0);
+    m_semaphore = eventfd(0, EFD_SEMAPHORE);
+    DS_PASSERT(m_semaphore != -1);
 }
 
 DS::MsgChannel::~MsgChannel()
 {
-    int result;
-
-    result = sem_destroy(&m_semaphore);
+    int result = close(m_semaphore);
     DS_PASSERT(result == 0);
 }
 
@@ -42,12 +40,17 @@ void DS::MsgChannel::putMessage(int type, void* payload)
     msg.m_payload = payload;
     m_queue.push(msg);
     m_queueMutex.unlock();
-    sem_post(&m_semaphore);
+
+    int result = eventfd_write(m_semaphore, 1);
+    DS_PASSERT(result == 0);
 }
 
 DS::FifoMessage DS::MsgChannel::getMessage()
 {
-    sem_wait(&m_semaphore);
+    eventfd_t value;
+    int result = eventfd_read(m_semaphore, &value);
+    DS_PASSERT(result == 0);
+
     m_queueMutex.lock();
     FifoMessage msg = m_queue.front();
     m_queue.pop();

--- a/NetIO/MsgChannel.h
+++ b/NetIO/MsgChannel.h
@@ -18,7 +18,6 @@
 #ifndef _DS_MSGCHANNEL_H
 #define _DS_MSGCHANNEL_H
 
-#include <semaphore.h>
 #include <queue>
 #include <mutex>
 
@@ -36,11 +35,12 @@ namespace DS
         MsgChannel();
         ~MsgChannel();
 
+        int fd() const { return m_semaphore; }
         void putMessage(int type, void* payload = 0);
         FifoMessage getMessage();
 
     private:
-        sem_t m_semaphore;
+        int m_semaphore;
         std::mutex m_queueMutex;
         std::queue<FifoMessage> m_queue;
     };

--- a/NetIO/MsgChannel.h
+++ b/NetIO/MsgChannel.h
@@ -38,6 +38,7 @@ namespace DS
         int fd() const { return m_semaphore; }
         void putMessage(int type, void* payload = 0);
         FifoMessage getMessage();
+        bool hasMessage();
 
     private:
         int m_semaphore;

--- a/NetIO/SockIO.cpp
+++ b/NetIO/SockIO.cpp
@@ -139,10 +139,6 @@ DS::SocketHandle DS::AcceptSock(const DS::SocketHandle sock)
     tv.tv_sec = NET_TIMEOUT;
     tv.tv_usec = 0;
     setsockopt(client->m_sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    // Allow 50ms on blocking sends to account for net suckiness
-    tv.tv_sec = 0;
-    tv.tv_usec = (50 * 1000);
-    setsockopt(client->m_sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
     // eap-tastic protocols require Nagle's algo be disabled
     setsockopt(client->m_sockfd, IPPROTO_TCP, TCP_NODELAY, &SOCK_YES, sizeof(SOCK_YES));
     return reinterpret_cast<SocketHandle>(client);

--- a/NetIO/SockIO.cpp
+++ b/NetIO/SockIO.cpp
@@ -17,6 +17,7 @@
 
 #include "SockIO.h"
 #include "errors.h"
+#include "settings.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -136,9 +137,7 @@ DS::SocketHandle DS::AcceptSock(const DS::SocketHandle sock)
         }
     }
     timeval tv;
-    // Client pings us every 30 seconds. A timeout of 45 gives us some wiggle room
-    // so networks can suck without kicking a client off.
-    tv.tv_sec = 45;
+    tv.tv_sec = NET_TIMEOUT;
     tv.tv_usec = 0;
     setsockopt(client->m_sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
     // Allow 50ms on blocking sends to account for net suckiness
@@ -187,6 +186,11 @@ uint32_t DS::GetAddress4(const char* lookup)
     freeaddrinfo(addrList);
 
     return ntohl(addr);
+}
+
+int DS::SockFd(const DS::SocketHandle sock)
+{
+    return reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd;
 }
 
 void DS::SendBuffer(const DS::SocketHandle sock, const void* buffer, size_t size, SendFlag mode)

--- a/NetIO/SockIO.h
+++ b/NetIO/SockIO.h
@@ -26,17 +26,6 @@
 
 namespace DS
 {
-    enum SendFlag
-    {
-        e_SendDefault,
-        e_SendNonBlocking = (1<<0),
-        e_SendNoRetry = (1<<1),
-        e_SendAllowFailure = (1<<2),
-
-        e_SendImmediately = (e_SendNonBlocking | e_SendNoRetry),
-        e_SendSpam = (e_SendImmediately | e_SendAllowFailure)
-    };
-
     typedef void* SocketHandle;
 
     SocketHandle BindSocket(const char* address, const char* port);
@@ -49,8 +38,7 @@ namespace DS
     uint32_t GetAddress4(const char* lookup);
     int SockFd(const SocketHandle sock);
 
-    void SendBuffer(const SocketHandle sock, const void* buffer,
-                    size_t size, SendFlag mode=e_SendDefault);
+    void SendBuffer(const SocketHandle sock, const void* buffer, size_t size);
     void SendFile(const SocketHandle sock, const void* buffer, size_t bufsz,
                   int fd, off_t* offset, size_t fdsz);
     void RecvBuffer(const SocketHandle sock, void* buffer, size_t size);

--- a/NetIO/SockIO.h
+++ b/NetIO/SockIO.h
@@ -47,6 +47,7 @@ namespace DS
 
     String SockIpAddress(const SocketHandle sock);
     uint32_t GetAddress4(const char* lookup);
+    int SockFd(const SocketHandle sock);
 
     void SendBuffer(const SocketHandle sock, const void* buffer,
                     size_t size, SendFlag mode=e_SendDefault);

--- a/settings.h
+++ b/settings.h
@@ -26,6 +26,8 @@
 
 #define CHUNK_SIZE (0x8000)
 
+#define NET_TIMEOUT (45)
+
 namespace DS
 {
     enum KeyType

--- a/streams.h
+++ b/streams.h
@@ -146,8 +146,8 @@ namespace DS
     class BufferStream : public Stream
     {
     public:
-        BufferStream() : m_buffer(0), m_position(0), m_size(0), m_alloc(0) { }
-        BufferStream(const void* data, size_t size) : m_buffer(0) { set(data, size); }
+        BufferStream() : m_buffer(0), m_position(0), m_size(0), m_alloc(0), m_refs(1) { }
+        BufferStream(const void* data, size_t size) : m_buffer(0), m_refs(1) { set(data, size); }
         virtual ~BufferStream() { delete[] m_buffer; }
 
         virtual ssize_t readBytes(void* buffer, size_t count);
@@ -170,10 +170,18 @@ namespace DS
         void set(const void* buffer, size_t size);
         void steal(uint8_t* buffer, size_t size);
 
+        void ref() { ++m_refs; }
+        void unref()
+        {
+            if (--m_refs == 0)
+                delete this;
+        }
+
     private:
         uint8_t* m_buffer;
         size_t m_position;
         size_t m_size, m_alloc;
+        std::atomic_int m_refs;
 
         BufferStream(const BufferStream& copy) { }
         void operator=(const BufferStream& copy) { }


### PR DESCRIPTION
DS's insistence to send broadcast type messages has had a history of deadlocking the daemon threads. There have been some inferior workarounds that punish players who are on crappy connections (namely, they are disconnected if they cause the daemon thread to block). This is what I consider the best fix for the situation.

Auth and game clients now have another `DS::MsgChannel` for srv2cli broadcasts. MsgChannel's semaphore was changed to an eventfd, which we use poll the socket and eventfd for client and server communication, respectively. The downside is that broadcast messages are now required to be allocated on the heap and refcounted. The plus side is that clients are not punished for being a little slow to handle messages, which is fairly important in cases with lots of messages flying around (eg lots of players linking out from something like a door run). I was also able to toss mutexes guarding the RC4 state and the socket send state because we only write from the client thread now