### PR TITLE
Bandage eventfd crashes

### DIFF
--- a/NetIO/MsgChannel.cpp
+++ b/NetIO/MsgChannel.cpp
@@ -29,7 +29,12 @@ DS::MsgChannel::MsgChannel()
 DS::MsgChannel::~MsgChannel()
 {
     int result = close(m_semaphore);
-    DS_PASSERT(result == 0);
+    if (result < 0) {
+        if (errno == EBADF) {
+            return;
+        }
+        DS_PASSERT(result == 0);
+    }
 }
 
 void DS::MsgChannel::putMessage(int type, void* payload)


### PR DESCRIPTION
This applies a hack bandaid to crashes that occur when closing an eventfd yields EBADF. I have no idea what's happening there, but if we get EBADF, clearly, we're already closed. The crash can be reproduced easily on master by connecting with the wrong build ID.