### PR TITLE
Add optional feature to use SHA256 for all login hashes

### DIFF
--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -94,7 +94,11 @@ struct Auth_LoginInfo : public Auth_ClientMessage
 {
     uint32_t m_clientChallenge;
     ST::string m_acctName;
+#ifdef USE_SHA256_LOGIN_HASH
+    DS::Sha256Hash m_passHash;
+#else
     DS::ShaHash m_passHash;
+#endif
     ST::string m_token, m_os;
 
     uint32_t m_billingType;

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -64,7 +64,11 @@ void dm_auth_addacct(Auth_AddAcct* msg)
         PQclear(result);
 
         ST::char_buffer pwBuf = msg->m_acctInfo.m_password.to_utf8();
+#ifdef USE_SHA256_LOGIN_HASH
+        DS::Sha256Hash pwHash = DS::Sha256Hash::Sha256(pwBuf.data(), pwBuf.size());
+#else
         DS::ShaHash pwHash = DS::ShaHash::Sha1(pwBuf.data(), pwBuf.size());
+#endif
         PostgresStrings<3> iparms;
         iparms.set(0, gen_uuid().toString());
         iparms.set(1, pwHash.toString());
@@ -162,6 +166,17 @@ void dm_auth_login(Auth_LoginInfo* info)
     }
 #endif
 
+#ifdef USE_SHA256_LOGIN_HASH
+    DS::Sha256Hash passhash = PQgetvalue(result, 0, 0);
+    if (passhash != info->m_passHash) {
+        printf("[Auth] %s: Failed login to account %s\n",
+               DS::SockIpAddress(info->m_client->m_sock).c_str(),
+               info->m_acctName.c_str());
+        PQclear(result);
+        SEND_REPLY(info, DS::e_NetAuthenticationFailed);
+        return;
+    }
+#else
     DS::ShaHash passhash = PQgetvalue(result, 0, 0);
     if (info->m_acctName.find("@") != -1 && info->m_acctName.find("@gametap") == -1) {
         DS::ShaHash challengeHash = DS::BuggyHashLogin(passhash,
@@ -186,6 +201,7 @@ void dm_auth_login(Auth_LoginInfo* info)
             return;
         }
     }
+#endif
 
     client->m_acctUuid = DS::Uuid(PQgetvalue(result, 0, 1));
     client->m_acctFlags = strtoul(PQgetvalue(result, 0, 2), 0, 10);

--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -132,7 +132,7 @@ void cb_login(AuthServer_Private& client)
     msg.m_clientChallenge = DS::CryptRecvValue<uint32_t>(client.m_sock, client.m_crypt);
     msg.m_acctName = DS::CryptRecvString(client.m_sock, client.m_crypt);
     DS::CryptRecvBuffer(client.m_sock, client.m_crypt,
-                        msg.m_passHash.m_data, sizeof(DS::ShaHash));
+                        msg.m_passHash.m_data, sizeof(msg.m_passHash.m_data));
     msg.m_token = DS::CryptRecvString(client.m_sock, client.m_crypt);
     msg.m_os = DS::CryptRecvString(client.m_sock, client.m_crypt);
     s_authChannel.putMessage(e_AuthClientLogin, reinterpret_cast<void*>(&msg));

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(PRODUCT_BUILD_TYPE  "50"        CACHE STRING "Build Type")
 set(PRODUCT_UUID        "ea489821-6c35-4bd0-9dae-bb17c585e680"
                                     CACHE STRING "Product UUID")
 
+set(DS_USE_SHA256_LOGIN_HASH OFF CACHE BOOL
+    "Use SHA256 hashes for login instead of SHA0/SHA1 (WARNING: Not compatible with old MOULa clients)")
+
 set(DS_HOOD_USER_NAME       "DS"
     CACHE STRING "Default Neighborhood Name")
 set(DS_HOOD_INST_NAME       "Neighborhood"
@@ -62,6 +65,10 @@ add_definitions(-DPRODUCT_UUID="${PRODUCT_UUID}")
 add_definitions(-DHOOD_USER_NAME="${DS_HOOD_USER_NAME}")
 add_definitions(-DHOOD_INST_NAME="${DS_HOOD_INST_NAME}")
 add_definitions(-DHOOD_POP_THRESHOLD=${DS_HOOD_POP_THRESHOLD})
+
+if(DS_USE_SHA256_LOGIN_HASH)
+    add_definitions(-DUSE_SHA256_LOGIN_HASH)
+endif()
 
 set(PlasMOUL_SOURCES
     PlasMOUL/AgeLinkStruct.cpp

--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -228,6 +228,7 @@ ST::string DS::CryptRecvString(const SocketHandle sock, CryptState crypt)
     return ST::string::from_utf16(result, ST::substitute_invalid);
 }
 
+#ifndef USE_SHA256_LOGIN_HASH
 DS::ShaHash DS::BuggyHashPassword(const ST::string& username, const ST::string& password)
 {
     ST::utf16_buffer wuser = username.to_utf16();
@@ -255,3 +256,4 @@ DS::ShaHash DS::BuggyHashLogin(const ShaHash& passwordHash, uint32_t serverChall
     buffer.m_pwhash = passwordHash;
     return ShaHash::Sha0(&buffer, sizeof(buffer));
 }
+#endif

--- a/NetIO/CryptIO.h
+++ b/NetIO/CryptIO.h
@@ -76,9 +76,11 @@ namespace DS
 
     ST::string CryptRecvString(const SocketHandle sock, CryptState crypt);
 
+#ifndef USE_SHA256_LOGIN_HASH
     ShaHash BuggyHashPassword(const ST::string& username, const ST::string& password);
     ShaHash BuggyHashLogin(const ShaHash& passwordHash, uint32_t serverChallenge,
                            uint32_t clientChallenge);
+#endif
 }
 
 #endif

--- a/NetIO/CryptIO.h
+++ b/NetIO/CryptIO.h
@@ -76,8 +76,10 @@ namespace DS
 
     ST::string CryptRecvString(const SocketHandle sock, CryptState crypt);
 
-#ifndef USE_SHA256_LOGIN_HASH
-    ShaHash BuggyHashPassword(const ST::string& username, const ST::string& password);
+#ifdef USE_SHA256_LOGIN_HASH
+    Sha256Hash HashLogin256(const ShaHash& passwordHash, uint32_t serverChallenge,
+                            uint32_t clientChallenge);
+#else
     ShaHash BuggyHashLogin(const ShaHash& passwordHash, uint32_t serverChallenge,
                            uint32_t clientChallenge);
 #endif

--- a/Types/ShaHash.cpp
+++ b/Types/ShaHash.cpp
@@ -17,6 +17,7 @@
 
 #include "ShaHash.h"
 #include <string_theory/format>
+#include <string_theory/codecs>
 #include <openssl/sha.h>
 #include <cstdlib>
 
@@ -66,12 +67,12 @@ void DS::ShaHash::swapBytes()
 
 ST::string DS::ShaHash::toString() const
 {
-    return ST::format("{08x}{08x}{08x}{08x}{08x}",
-                      SWAP_BYTES(m_data[0]), SWAP_BYTES(m_data[1]),
-                      SWAP_BYTES(m_data[2]), SWAP_BYTES(m_data[3]),
-                      SWAP_BYTES(m_data[4]));
+    // Assuming the bytes are already in the right order, we can just
+    // convert them directly as a block of bytes instead of 5 words.
+    return ST::hex_encode(m_data, sizeof(m_data));
 }
 
+#ifndef USE_SHA256_LOGIN_HASH
 DS::ShaHash DS::ShaHash::Sha0(const void* data, size_t size)
 {
     ShaHash result;
@@ -79,11 +80,32 @@ DS::ShaHash DS::ShaHash::Sha0(const void* data, size_t size)
         reinterpret_cast<unsigned char*>(result.m_data));
     return result;
 }
+#endif
 
 DS::ShaHash DS::ShaHash::Sha1(const void* data, size_t size)
 {
     ShaHash result;
     SHA1(reinterpret_cast<const unsigned char*>(data), size,
          reinterpret_cast<unsigned char*>(result.m_data));
+    return result;
+}
+
+
+/* Sha256Hash */
+DS::Sha256Hash::Sha256Hash(const char* struuid)
+{
+    ST::hex_decode(struuid, m_data, sizeof(m_data));
+}
+
+ST::string DS::Sha256Hash::toString() const
+{
+    return ST::hex_encode(m_data, sizeof(m_data));
+}
+
+DS::Sha256Hash DS::Sha256Hash::Sha256(const void* data, size_t size)
+{
+    Sha256Hash result;
+    SHA256(reinterpret_cast<const unsigned char*>(data), size,
+           reinterpret_cast<unsigned char*>(result.m_data));
     return result;
 }

--- a/Types/ShaHash.h
+++ b/Types/ShaHash.h
@@ -44,11 +44,39 @@ namespace DS
 
         ST::string toString() const;
 
+#ifndef USE_SHA256_LOGIN_HASH
+        // SHA0 is only needed if we're using the old email-based
+        // MOULa-compatible login hashing
         static ShaHash Sha0(const void* data, size_t size);
+#endif
         static ShaHash Sha1(const void* data, size_t size);
 
     public:
         uint32_t m_data[5];
+    };
+
+    class Sha256Hash
+    {
+    public:
+        Sha256Hash() { memset(m_data, 0, sizeof(m_data)); }
+
+        Sha256Hash(const uint8_t* bytes)
+        { memcpy(m_data, bytes, sizeof(m_data)); }
+
+        Sha256Hash(const char* struuid);
+
+        bool operator==(const Sha256Hash& other) const
+        { return memcmp(m_data, other.m_data, sizeof(m_data)) == 0; }
+
+        bool operator!=(const Sha256Hash& other) const
+        { return memcmp(m_data, other.m_data, sizeof(m_data)) != 0; }
+
+        ST::string toString() const;
+
+        static Sha256Hash Sha256(const void* data, size_t size);
+
+    public:
+        uint8_t m_data[32];
     };
 }
 

--- a/db/dbinit.sql
+++ b/db/dbinit.sql
@@ -32,7 +32,7 @@ SET default_with_oids = false;
 CREATE TABLE "Accounts" (
     idx integer NOT NULL,
     "Login" character varying(64) NOT NULL,
-    "PassHash" character(64) NOT NULL,
+    "PassHash" character(40) NOT NULL,
     "AcctUuid" uuid NOT NULL,
     "AcctFlags" integer DEFAULT 0 NOT NULL,
     "BillingType" integer DEFAULT 0 NOT NULL

--- a/db/dbinit.sql
+++ b/db/dbinit.sql
@@ -32,7 +32,7 @@ SET default_with_oids = false;
 CREATE TABLE "Accounts" (
     idx integer NOT NULL,
     "Login" character varying(64) NOT NULL,
-    "PassHash" character(40) NOT NULL,
+    "PassHash" character(64) NOT NULL,
     "AcctUuid" uuid NOT NULL,
     "AcctFlags" integer DEFAULT 0 NOT NULL,
     "BillingType" integer DEFAULT 0 NOT NULL


### PR DESCRIPTION
This allows a server admin to replace all login hashes with SHA256 instead of the old/broken SHA0/SHA1 combination.

Advantages:
* SHA0 is no longer used anywhere (Addresses #111).
* Only one code path regardless of whether the login is an email or a "plain" username.
* Use extra challenge hashing from SHA0 method, which was not previously applied to the SHA1 method.
* Doesn't require a database migration or account upgrade (stored password hashes were already SHA1, which is sufficient for adding to the challenge hash).

Disadvantages:
* **Not backwards compatible with unmodified clients.**
* Currently no way for a client or server to detect whether the new feature is enabled.  Shard admins will have to alter another parameter (such as the build number) to indicate the incompatible change after upgrading.

Note that the feature is optional (set DS_USE_SHA256_LOGIN_HASH in CMake), and defaults to OFF.  That is, the default behavior if this is merged is unchanged.  To update a given server, you'll need to set the flag and rebuild both the server and the client.