### PR TITLE
Dynamically detect SHA algorithms and switch to EVP APIs.

### DIFF
--- a/dsmain.cpp
+++ b/dsmain.cpp
@@ -27,6 +27,7 @@
 #include "settings.h"
 #include <string_theory/codecs>
 #include <string_theory/stdio>
+#include <openssl/evp.h>
 #include <readline.h>
 #include <history.h>
 #include <signal.h>
@@ -126,6 +127,8 @@ int main(int argc, char* argv[])
         fputs("Do not run this server as root!\n", stderr);
         return 1;
     }
+
+    OpenSSL_add_all_digests();
 
     // Preset some arguments
     const char* settings = 0;


### PR DESCRIPTION
Dynamically detect available SHA algorithms and assert when one isn't available (fixes compilation but not functionality with current OpenSSL versions that remove SHA0).  This is the DirtSand equivalent to H-uru/libhsplasma#101