### PR TITLE
Require string_theory 1.7 for ST::hash_i fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ find_package(Postgres REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Readline REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(string_theory 1.3 REQUIRED)
+find_package(string_theory 1.7 REQUIRED)
 
 include_directories("${CMAKE_SOURCE_DIR}"
                     "${CMAKE_SOURCE_DIR}/PlasMOUL"


### PR DESCRIPTION
Versions of string_theory prior to 1.7 would incorrectly use the case-sensitive hash for both `ST::hash` and `ST::hash_i`