### PR TITLE
Error handling refactor and cleanup

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -1257,19 +1257,17 @@ void dm_authDaemon()
                 DS_DASSERT(0);
                 break;
             }
-        } catch (const DS::AssertException& ex) {
-            fprintf(stderr, "[Auth] Assertion failed at %s:%ld:  %s\n",
-                    ex.m_file, ex.m_line, ex.m_cond);
+        } catch (const std::exception& ex) {
+            fprintf(stderr, "[Auth] Exception raised processing message: %s\n",
+                    ex.what());
             if (msg.m_payload) {
                 // Keep clients from blocking on a reply
                 SEND_REPLY(reinterpret_cast<Auth_ClientMessage*>(msg.m_payload),
                            DS::e_NetInternalError);
             }
-        } catch (const DS::PacketSizeOutOfBounds& ex) {
-            fprintf(stderr, "[Auth] Client packet size too large: Requested %u bytes\n",
-                    ex.requestedSize());
         }
     }
 
-    dm_auth_shutdown();
+    // This line should be unreachable
+    DS_PASSERT(false);
 }

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -35,16 +35,9 @@ std::unordered_map<ST::string, SDL::State, ST::hash_i, ST::equal_i> s_globalStat
 #define SEND_REPLY(msg, result) \
     msg->m_client->m_channel.putMessage(result)
 
-static inline void check_postgres()
-{
-    if (PQstatus(s_postgres) == CONNECTION_BAD)
-        PQreset(s_postgres);
-    DS_DASSERT(PQstatus(s_postgres) == CONNECTION_OK);
-}
-
 void dm_auth_addacct(Auth_AddAcct* msg)
 {
-    check_postgres();
+    check_postgres(s_postgres);
 
     DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "SELECT idx, \"AcctUuid\" FROM auth.\"Accounts\""
@@ -108,7 +101,7 @@ void dm_auth_shutdown()
 
 void dm_auth_login(Auth_LoginInfo* info)
 {
-    check_postgres();
+    check_postgres(s_postgres);
 
 #ifdef DEBUG
     printf("[Auth] Login U:%s P:%s T:%s O:%s\n",
@@ -265,7 +258,7 @@ void dm_auth_disconnect(Auth_ClientMessage* msg)
     AuthServer_Private* client = reinterpret_cast<AuthServer_Private*>(msg->m_client);
     if (client->m_player.m_playerId) {
         // Mark player as offline
-        check_postgres();
+        check_postgres(s_postgres);
         DS::PGresultRef result = DS::PQexecVA(s_postgres,
                 "UPDATE vault.\"Nodes\" SET"
                 "    \"Int32_1\"=0, \"String64_1\"='',"
@@ -292,7 +285,7 @@ void dm_auth_disconnect(Auth_ClientMessage* msg)
 
 void dm_auth_setPlayer(Auth_ClientMessage* msg)
 {
-    check_postgres();
+    check_postgres(s_postgres);
 
     AuthServer_Private* client = reinterpret_cast<AuthServer_Private*>(msg->m_client);
     DS::PGresultRef result = DS::PQexecVA(s_postgres,
@@ -930,7 +923,7 @@ void dm_auth_acctFlags(Auth_AccountFlags* msg)
 
 void dm_auth_addAllPlayers(Auth_AddAllPlayers* msg)
 {
-    check_postgres();
+    check_postgres(s_postgres);
 
     if (v_has_node(msg->m_playerId, s_allPlayers)) {
         if (!v_unref_node(msg->m_playerId, s_allPlayers)) {

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -211,7 +211,11 @@ void dm_auth_bcast_node(uint32_t nodeIdx, const DS::Uuid& revision)
         if (!(v_has_node(client->m_ageNodeId, nodeIdx) || v_has_node(client->m_player.m_playerId, nodeIdx)))
             continue;
         msg->ref();
-        client->m_broadcast.putMessage(e_AuthToCli_VaultNodeChanged, msg);
+        try {
+            client->m_broadcast.putMessage(e_AuthToCli_VaultNodeChanged, msg);
+        } catch (const std::exception& ex) {
+            fprintf(stderr, "[Auth] WARNING: %s\n", ex.what());
+        }
     }
     msg->unref();
 }
@@ -229,7 +233,11 @@ void dm_auth_bcast_ref(const DS::Vault::NodeRef& ref)
         if (!(v_has_node(client->m_ageNodeId, ref.m_parent) || v_has_node(client->m_player.m_playerId, ref.m_parent)))
             continue;
         msg->ref();
-        client->m_broadcast.putMessage(e_AuthToCli_VaultNodeAdded, msg);
+        try {
+            client->m_broadcast.putMessage(e_AuthToCli_VaultNodeAdded, msg);
+        } catch (const std::exception& ex) {
+            fprintf(stderr, "[Auth] WARNING: %s\n", ex.what());
+        }
     }
     msg->unref();
 }
@@ -246,7 +254,11 @@ void dm_auth_bcast_unref(const DS::Vault::NodeRef& ref)
         if (!(v_has_node(client->m_ageNodeId, ref.m_parent) || v_has_node(client->m_player.m_playerId, ref.m_parent)))
             continue;
         msg->ref();
-        client->m_broadcast.putMessage(e_AuthToCli_VaultNodeRemoved, msg);
+        try {
+            client->m_broadcast.putMessage(e_AuthToCli_VaultNodeRemoved, msg);
+        } catch (const std::exception& ex) {
+            fprintf(stderr, "[Auth] WARNING: %s\n", ex.what());
+        }
     }
     msg->unref();
 }
@@ -1068,8 +1080,9 @@ void dm_authDaemon()
     }
 
     for ( ;; ) {
-        DS::FifoMessage msg = s_authChannel.getMessage();
+        DS::FifoMessage msg { -1, nullptr };
         try {
+            msg = s_authChannel.getMessage();
             switch (msg.m_messageType) {
             case e_AuthShutdown:
                 dm_auth_shutdown();

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -56,8 +56,7 @@ void dm_auth_addacct(Auth_AddAcct* msg)
         result = DS::PQexecVA(s_postgres,
                 "INSERT INTO auth.\"Accounts\""
                 "    (\"AcctUuid\", \"PassHash\", \"Login\", \"AcctFlags\", \"BillingType\")"
-                "    VALUES ($1, $2, $3, 0, 1)"
-                "    returning idx",
+                "    VALUES ($1, $2, $3, 0, 1)",
                 gen_uuid().toString(), pwHash.toString(),
                 msg->m_acctInfo.m_acctName);
         if (PQresultStatus(result) != PGRES_TUPLES_OK) {
@@ -66,7 +65,6 @@ void dm_auth_addacct(Auth_AddAcct* msg)
             SEND_REPLY(msg, DS::e_NetInternalError);
             return;
         }
-        DS_DASSERT(PQntuples(result) == 1);
         SEND_REPLY(msg, DS::e_NetSuccess);
     } else {
         fprintf(stderr, "Error: Account already exists (ID %s; UUID %s)\n",
@@ -407,8 +405,7 @@ void dm_auth_createPlayer(Auth_PlayerCreate* msg)
     result = DS::PQexecVA(s_postgres,
             "INSERT INTO auth.\"Players\""
             "    (\"AcctUuid\", \"PlayerIdx\", \"PlayerName\", \"AvatarShape\", \"Explorer\")"
-            "    VALUES ($1, $2, $3, $4, $5)"
-            "    RETURNING idx",
+            "    VALUES ($1, $2, $3, $4, $5)",
             client->m_acctUuid.toString(), msg->m_player.m_playerId,
             msg->m_player.m_playerName, msg->m_player.m_avatarModel,
             msg->m_player.m_explorer);
@@ -418,7 +415,6 @@ void dm_auth_createPlayer(Auth_PlayerCreate* msg)
         SEND_REPLY(msg, DS::e_NetInternalError);
         return;
     }
-    DS_DASSERT(PQntuples(result) == 1);
     SEND_REPLY(msg, DS::e_NetSuccess);
 }
 
@@ -1013,7 +1009,6 @@ void dm_auth_update_globalSDL(Auth_UpdateGlobalSDL* msg)
                 fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                         __FILE__, __LINE__, PQerrorMessage(s_postgres));
                 // This doesn't block continuing...
-                DS_DASSERT(false);
             }
 
             DS::GameServer_UpdateGlobalSDL(msg->m_ageFilename);
@@ -1067,7 +1062,6 @@ void dm_authDaemon()
         fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                  __FILE__, __LINE__, PQerrorMessage(s_postgres));
         // This doesn't block continuing...
-        DS_DASSERT(false);
     }
 
     for ( ;; ) {

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -101,11 +101,9 @@ void dm_auth_login(Auth_LoginInfo* info)
 {
     check_postgres(s_postgres);
 
-#ifdef DEBUG
-    printf("[Auth] Login U:%s P:%s T:%s O:%s\n",
-           info->m_acctName.c_str(), info->m_passHash.toString().c_str(),
-           info->m_token.c_str(), info->m_os.c_str());
-#endif
+    DEBUG_printf("[Auth] Login U:%s P:%s T:%s O:%s\n",
+                 info->m_acctName.c_str(), info->m_passHash.toString().c_str(),
+                 info->m_token.c_str(), info->m_os.c_str());
 
     // Reset UUID in case authentication fails
     AuthServer_Private* client = reinterpret_cast<AuthServer_Private*>(info->m_client);
@@ -298,9 +296,9 @@ void dm_auth_setPlayer(Auth_ClientMessage* msg)
         return;
     }
     if (PQntuples(result) == 0) {
-        printf("[Auth] {%s} requested invalid player ID (%u)\n",
-               client->m_acctUuid.toString().c_str(),
-               client->m_player.m_playerId);
+        fprintf(stderr, "[Auth] {%s} requested invalid player ID (%u)\n",
+                client->m_acctUuid.toString().c_str(),
+                client->m_player.m_playerId);
         client->m_player.m_playerId = 0;
         SEND_REPLY(msg, DS::e_NetPlayerNotFound);
         return;
@@ -422,11 +420,9 @@ void dm_auth_deletePlayer(Auth_PlayerDelete* msg)
 {
     AuthServer_Private* client = reinterpret_cast<AuthServer_Private*>(msg->m_client);
 
-#ifdef DEBUG
-    printf("[Auth] {%s} requesting deletion of PlayerId (%d)\n",
-            client->m_acctUuid.toString().c_str(),
-            msg->m_playerId);
-#endif
+    DEBUG_printf("[Auth] {%s} requesting deletion of PlayerId (%d)\n",
+                 client->m_acctUuid.toString().c_str(),
+                 msg->m_playerId);
 
     // Check for existing player
     DS::PGresultRef result = DS::PQexecVA(s_postgres,
@@ -538,13 +534,11 @@ void dm_auth_createAge(Auth_AgeCreate* msg)
 
 void dm_auth_findAge(Auth_GameAge* msg)
 {
-#ifdef DEBUG
-    printf("[Auth] %s Requesting game server {%s} %s\n",
-           DS::SockIpAddress(msg->m_client->m_sock).c_str(),
-           msg->m_instanceId.toString().c_str(), msg->m_name.c_str());
-#endif
-
     const ST::string instanceIdString = msg->m_instanceId.toString();
+    DEBUG_printf("[Auth] %s Requesting game server {%s} %s\n",
+                 DS::SockIpAddress(msg->m_client->m_sock).c_str(),
+                 instanceIdString.c_str(), msg->m_name.c_str());
+
     DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "SELECT idx, \"AgeIdx\", \"DisplayName\" FROM game.\"Servers\""
             "    WHERE \"AgeUuid\"=$1",
@@ -1280,5 +1274,5 @@ void dm_authDaemon()
     }
 
     // This line should be unreachable
-    DS_PASSERT(false);
+    DS_ASSERT(false);
 }

--- a/AuthServ/AuthManifest.cpp
+++ b/AuthServ/AuthManifest.cpp
@@ -71,6 +71,10 @@ uint32_t DS::AuthManifest::encodeToStream(DS::Stream* stream) const
     }
     stream->write<uint16_t>(0);
 
-    DS_DASSERT((stream->tell() - start) % sizeof(char16_t) == 0);
+    if ((stream->tell() - start) % sizeof(char16_t) != 0) {
+        fputs("WARNING: Encoded manifest data was not evenly divisible by "
+              "UTF-16 character size.  The recipient client may crash...\n",
+              stderr);
+    }
     return (stream->tell() - start) / sizeof(char16_t);
 }

--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -43,7 +43,8 @@ void auth_init(AuthServer_Private& client)
 {
     /* Auth server header:  size, null uuid */
     uint32_t size = DS::RecvValue<uint32_t>(client.m_sock);
-    DS_PASSERT(size == 20);
+    if (size != 20)
+        throw DS::InvalidConnectionHeader();
     DS::Uuid uuid;
     DS::RecvBuffer(client.m_sock, uuid.m_bytes, sizeof(uuid.m_bytes));
 
@@ -53,7 +54,8 @@ void auth_init(AuthServer_Private& client)
 
     /* Establish encryption, and write reply body */
     uint8_t msgId = DS::RecvValue<uint8_t>(client.m_sock);
-    DS_PASSERT(msgId == DS::e_CliToServConnect);
+    if (msgId != DS::e_CliToServConnect)
+        throw DS::InvalidConnectionHeader();
     uint8_t msgSize = DS::RecvValue<uint8_t>(client.m_sock);
     if (msgSize == 2) {
         // no seed... client wishes unencrypted connection (that's okay, nobody
@@ -63,7 +65,8 @@ void auth_init(AuthServer_Private& client)
     } else {
         uint8_t Y[64];
         memset(Y, 0, sizeof(Y));
-        DS_PASSERT(msgSize <= 66);
+        if (msgSize > 66)
+            throw DS::InvalidConnectionHeader();
         DS::RecvBuffer(client.m_sock, Y, 64 - (66 - msgSize));
         BYTE_SWAP_BUFFER(Y, 64);
 

--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -1034,14 +1034,11 @@ void wk_authWorker(DS::SocketHandle sockp)
             if (fds[1].revents & POLLIN)
                 cb_broadcast(client);
         }
-    } catch (const DS::AssertException& ex) {
-        fprintf(stderr, "[Auth] Assertion failed at %s:%ld:  %s\n",
-                ex.m_file, ex.m_line, ex.m_cond);
-    } catch (const DS::PacketSizeOutOfBounds& ex) {
-        fprintf(stderr, "[Auth] Client packet size too large: Requested %u bytes\n",
-                ex.requestedSize());
     } catch (const DS::SockHup&) {
         // Socket closed...
+    } catch (const std::exception& ex) {
+        fprintf(stderr, "[Auth] Error processing client message from %s: %s\n",
+                DS::SockIpAddress(sockp).c_str(), ex.what());
     }
 
     Auth_ClientMessage disconMsg;

--- a/AuthServ/AuthServer.h
+++ b/AuthServ/AuthServer.h
@@ -35,16 +35,6 @@ namespace DS
     bool AuthServer_AddAllPlayersFolder(uint32_t playerId);
     bool AuthServer_ChangeGlobalSDL(const ST::string& ageName, const ST::string& var,
                                     const ST::string& value);
-
-    class DbException : public std::exception
-    {
-    public:
-        DbException() throw() { }
-        virtual ~DbException() throw() { }
-
-        virtual const char* what() const throw()
-        { return "[DbException] Postgres error"; }
-    };
 }
 
 #endif

--- a/AuthServ/AuthVault.cpp
+++ b/AuthServ/AuthVault.cpp
@@ -354,7 +354,6 @@ bool v_check_global_sdl(const ST::string& name, SDL::StateDescriptor* desc)
                 fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                         __FILE__, __LINE__, PQerrorMessage(s_postgres));
                 // This doesn't block continuing...
-                DS_DASSERT(false);
             }
         }
         s_globalStates[name] = state;
@@ -1034,7 +1033,6 @@ DS::Vault::Node v_fetch_node(uint32_t nodeIdx)
     if (PQntuples(result) == 0) {
         return DS::Vault::Node();
     }
-    DS_DASSERT(PQntuples(result) == 1);
 
     DS::Vault::Node node;
     node.set_NodeIdx(strtoul(PQgetvalue(result, 0, 0), 0, 10));

--- a/AuthServ/AuthVault.cpp
+++ b/AuthServ/AuthVault.cpp
@@ -42,7 +42,7 @@ static inline void check_postgres()
 DS::Uuid gen_uuid()
 {
     check_postgres();
-    PGresultRef result = PQexec(s_postgres, "SELECT uuid_generate_v4()");
+    DS::PGresultRef result = PQexec(s_postgres, "SELECT uuid_generate_v4()");
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -69,13 +69,11 @@ DS::Blob gen_default_sdl(const ST::string& filename)
 static std::tuple<uint32_t, uint32_t>
 find_a_friendly_neighborhood_for_our_new_visitor()
 {
-    PostgresStrings<2> parms;
-    parms.set(0, DS::Settings::HoodUserName());
-    PGresultRef result = PQexecParams(s_postgres,
-                         "SELECT idx FROM vault.\"Nodes\" WHERE \"String64_2\"="
-                         "    'Neighborhood' AND \"String64_4\" = $1"
-                         "    ORDER BY \"Int32_1\"",
-                         1, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT idx FROM vault.\"Nodes\" WHERE \"String64_2\"="
+            "    'Neighborhood' AND \"String64_4\" = $1"
+            "    ORDER BY \"Int32_1\"",
+            DS::Settings::HoodUserName());
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -105,10 +103,8 @@ find_a_friendly_neighborhood_for_our_new_visitor()
     }
 
     // It's important to BCast new hood members, so we'll return the ageOwners folder
-    parms.set(0, theHoodInfo);
-    parms.set(1, DS::Vault::e_AgeOwnersFolder);
-    result = PQexecParams(s_postgres, "SELECT idx FROM vault.find_folder($1, $2);",
-                          2, 0, parms.m_values, 0, 0, 0);
+    result = DS::PQexecVA(s_postgres, "SELECT idx FROM vault.find_folder($1, $2);",
+                          theHoodInfo, DS::Vault::e_AgeOwnersFolder);
     if (PQresultStatus(result) == PGRES_TUPLES_OK) {
         uint32_t ownersFolder = strtoul(PQgetvalue(result, 0, 0), 0, 10);
         return std::make_tuple(theHoodInfo, ownersFolder);
@@ -121,18 +117,15 @@ find_a_friendly_neighborhood_for_our_new_visitor()
 
 static uint32_t find_public_age_1(const ST::string& filename, const DS::Uuid& uuid=DS::Uuid())
 {
-    PostgresStrings<2> parms;
-    parms.set(0, filename);
-    PGresultRef result;
+    DS::PGresultRef result;
     if (uuid.isNull()) {
-        result = PQexecParams(s_postgres, "SELECT idx FROM vault.\"Nodes\""
+        result = DS::PQexecVA(s_postgres, "SELECT idx FROM vault.\"Nodes\""
                               "    WHERE \"Int32_2\" = 1 AND \"String64_2\"=$1",
-                              1, 0, parms.m_values, 0, 0, 0);
+                              filename);
     } else {
-        parms.set(1, uuid.toString());
-        result = PQexecParams(s_postgres, "SELECT idx FROM vault.\"Nodes\""
+        result = DS::PQexecVA(s_postgres, "SELECT idx FROM vault.\"Nodes\""
                               "    WHERE \"Int32_2\" = 1 AND \"String64_2\"=$1 AND \"Uuid_1\"=$2",
-                              2, 0, parms.m_values, 0, 0, 0);
+                              filename, uuid.toString());
     }
     uint32_t ageInfoId = 0;
     if (PQresultStatus(result) == PGRES_TUPLES_OK) {
@@ -216,12 +209,10 @@ std::list<AuthServer_AgeInfo> configure_static_ages()
 
 bool dm_vault_init()
 {
-    PostgresStrings<1> sparm;
-    sparm.set(0, DS::Vault::e_NodeSystem);
-    PGresultRef result = PQexecParams(s_postgres,
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "SELECT \"idx\" FROM vault.\"Nodes\""
             "    WHERE \"NodeType\"=$1",
-            1, 0, sparm.m_values, 0, 0, 0);
+            DS::Vault::e_NodeSystem);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -262,13 +253,10 @@ bool dm_global_sdl_init()
 
 bool dm_all_players_init()
 {
-    PostgresStrings<2> parms;
-    parms.set(0, DS::Vault::e_NodePlayerInfoList);
-    parms.set(1, DS::Vault::e_AllPlayersFolder);
-    PGresultRef result = PQexecParams(s_postgres,
-                                      "SELECT idx FROM vault.\"Nodes\""
-                                      "    WHERE \"NodeType\"=$1 AND \"Int32_1\"=$2",
-                                      2, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT idx FROM vault.\"Nodes\""
+            "    WHERE \"NodeType\"=$1 AND \"Int32_1\"=$2",
+            DS::Vault::e_NodePlayerInfoList, DS::Vault::e_AllPlayersFolder);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -280,10 +268,11 @@ bool dm_all_players_init()
     }
 
     // create that mutha
-    result = PQexecParams(s_postgres,
+    result = DS::PQexecVA(s_postgres,
                           "INSERT INTO vault.\"Nodes\" (\"NodeType\", \"Int32_1\")"
                           "    VALUES ($1, $2) RETURNING idx",
-                          2, 0, parms.m_values, 0, 0, 0);
+                          DS::Vault::e_NodePlayerInfoList,
+                          DS::Vault::e_AllPlayersFolder);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -292,10 +281,9 @@ bool dm_all_players_init()
     s_allPlayers = strtoul(PQgetvalue(result, 0, 0), 0, 10);
 
     // add the already existing players
-    parms.set(0, DS::Vault::e_NodePlayerInfo);
-    result = PQexecParams(s_postgres,
+    result = DS::PQexecVA(s_postgres,
                           "SELECT idx FROM vault.\"Nodes\" WHERE \"NodeType\"=$1",
-                          1, 0, parms.m_values, 0, 0, 0);
+                          DS::Vault::e_NodePlayerInfo);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -332,11 +320,10 @@ bool v_check_global_sdl(const ST::string& name, SDL::StateDescriptor* desc)
         return true;
     }
 
-    PostgresStrings<2> parms;
-    parms.set(0, name);
-    PGresultRef result = PQexecParams(s_postgres, "SELECT idx,\"SdlBlob\" FROM vault.\"GlobalStates\""
-                                      "WHERE \"Descriptor\"=$1 LIMIT 1",
-                                      1, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT idx,\"SdlBlob\" FROM vault.\"GlobalStates\""
+            "    WHERE \"Descriptor\"=$1 LIMIT 1",
+            name);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -347,10 +334,10 @@ bool v_check_global_sdl(const ST::string& name, SDL::StateDescriptor* desc)
         s_globalStates[name] = SDL::State(desc);
         DS::Blob blob = s_globalStates[name].toBlob();
 
-        parms.set(1, ST::base64_encode(blob.buffer(), blob.size()));
-        result = PQexecParams(s_postgres, "INSERT INTO vault.\"GlobalStates\""
-                              "    (\"Descriptor\", \"SdlBlob\") VALUES ($1, $2)",
-                              2, 0, parms.m_values, 0, 0, 0);
+        result = DS::PQexecVA(s_postgres,
+                "INSERT INTO vault.\"GlobalStates\""
+                "    (\"Descriptor\", \"SdlBlob\") VALUES ($1, $2)",
+                name, ST::base64_encode(blob.buffer(), blob.size()));
         if (PQresultStatus(result) != PGRES_COMMAND_OK) {
             fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                     __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -366,11 +353,10 @@ bool v_check_global_sdl(const ST::string& name, SDL::StateDescriptor* desc)
             state.update();
             blob = state.toBlob();
 
-            parms.set(0, idx);
-            parms.set(1, ST::base64_encode(blob.buffer(), blob.size()));
-            result = PQexecParams(s_postgres, "UPDATE vault.\"GlobalStates\""
-                                  "SET \"SdlBlob\"=$2 WHERE idx=$1",
-                                  2, 0, parms.m_values, 0, 0, 0);
+            result = DS::PQexecVA(s_postgres,
+                    "UPDATE vault.\"GlobalStates\""
+                    "    SET \"SdlBlob\"=$1 WHERE idx=$2",
+                    ST::base64_encode(blob.buffer(), blob.size()), idx);
             if (PQresultStatus(result) != PGRES_COMMAND_OK) {
                 fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                         __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -390,11 +376,10 @@ SDL::State v_find_global_sdl(const ST::string& ageName)
         return nullptr;
     check_postgres();
 
-    PostgresStrings<1> parms;
-    parms.set(0, ageName);
-    PGresultRef result = PQexecParams(s_postgres, "SELECT \"SdlBlob\" FROM vault.\"GlobalStates\""
-                                      "WHERE \"Descriptor\"=$1 LIMIT 1",
-                                      1, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT \"SdlBlob\" FROM vault.\"GlobalStates\""
+            "    WHERE \"Descriptor\"=$1 LIMIT 1",
+            ageName);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -415,7 +400,7 @@ v_create_age(AuthServer_AgeInfo age, uint32_t flags)
     if (seqNumber < 0) {
         check_postgres();
 
-        PGresultRef result = PQexec(s_postgres, "SELECT nextval('game.\"AgeSeqNumber\"'::regclass)");
+        DS::PGresultRef result = PQexec(s_postgres, "SELECT nextval('game.\"AgeSeqNumber\"'::regclass)");
         if (PQresultStatus(result) != PGRES_TUPLES_OK) {
             fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                     __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -561,17 +546,11 @@ v_create_age(AuthServer_AgeInfo age, uint32_t flags)
                            : !age.m_instName.is_empty() ? age.m_instName
                            : age.m_filename;
 
-        PostgresStrings<5> parms;
-        parms.set(0, age.m_ageId.toString());
-        parms.set(1, age.m_filename);
-        parms.set(2, agedesc);
-        parms.set(3, ageNode);
-        parms.set(4, ageSdlNode);
-        PGresultRef result = PQexecParams(s_postgres,
+        DS::PGresultRef result = DS::PQexecVA(s_postgres,
                 "INSERT INTO game.\"Servers\""
                 "    (\"AgeUuid\", \"AgeFilename\", \"DisplayName\", \"AgeIdx\", \"SdlIdx\")"
                 "    VALUES ($1, $2, $3, $4, $5)",
-                5, 0, parms.m_values, 0, 0, 0);
+                age.m_ageId.toString(), age.m_filename, agedesc, ageNode, ageSdlNode);
         if (PQresultStatus(result) != PGRES_COMMAND_OK) {
             fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                     __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -747,12 +726,9 @@ v_create_player(DS::Uuid acctId, const AuthServer_PlayerInfo& player)
         return std::make_tuple(0, 0, 0);
 
     {
-        PostgresStrings<2> parms;
-        parms.set(0, std::get<1>(reltoAge));
-        parms.set(1, DS::Vault::e_AgeOwnersFolder);
-        PGresultRef result = PQexecParams(s_postgres,
+        DS::PGresultRef result = DS::PQexecVA(s_postgres,
                 "SELECT idx FROM vault.find_folder($1, $2);",
-                2, 0, parms.m_values, 0, 0, 0);
+                std::get<1>(reltoAge), DS::Vault::e_AgeOwnersFolder);
         if (PQresultStatus(result) != PGRES_TUPLES_OK) {
             fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                     __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -822,7 +798,7 @@ uint32_t v_create_node(const DS::Vault::Node& node)
     /* This should be plenty to store everything we need without a bunch
      * of dynamic reallocations
      */
-    PostgresStrings<31> parms;
+    DS::PostgresStrings<31> parms;
     char fieldbuf[1024];
 
     size_t parmcount = 0;
@@ -833,7 +809,7 @@ uint32_t v_create_node(const DS::Vault::Node& node)
             parms.set(parmcount++, value); \
             fieldp += sprintf(fieldp, "\"" #name "\","); \
         }
-    int now = time(0);
+    int now = static_cast<int>(time(nullptr));
     SET_FIELD(CreateTime, now);
     SET_FIELD(ModifyTime, now);
     if (node.has_CreateAgeName())
@@ -896,26 +872,25 @@ uint32_t v_create_node(const DS::Vault::Node& node)
         SET_FIELD(Blob_2, ST::base64_encode(node.m_Blob_2.buffer(), node.m_Blob_2.size()));
     #undef SET_FIELD
 
-    DS_DASSERT(fieldp - fieldbuf < 1024);
+    DS_DASSERT(fieldp < fieldbuf + sizeof(fieldbuf));
     *(fieldp - 1) = ')';    // Get rid of the last comma
     ST::string_stream queryStr;
     queryStr << "INSERT INTO vault.\"Nodes\" (";
     queryStr << fieldbuf;
 
     fieldp = fieldbuf;
-    for (size_t i=0; i<parmcount; ++i) {
-        sprintf(fieldp, "$%zu,", i+1);
-        fieldp += strlen(fieldp);
-    }
-    DS_DASSERT(fieldp - fieldbuf < 1024);
+    for (size_t i=0; i<parmcount; ++i)
+        fieldp += sprintf(fieldp, "$%zu,", i+1);
+    DS_DASSERT(fieldp < fieldbuf + sizeof(fieldbuf));
     *(fieldp - 1) = ')';    // Get rid of the last comma
     queryStr << "\n    VALUES (";
     queryStr << fieldbuf;
     queryStr << "\n    RETURNING idx";
 
     check_postgres();
-    PGresultRef result = PQexecParams(s_postgres, queryStr.to_string().c_str(),
-                                      parmcount, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = PQexecParams(s_postgres, queryStr.to_string().c_str(),
+                                          parmcount, nullptr, parms.m_values,
+                                          nullptr, nullptr, 0);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -933,14 +908,10 @@ bool v_has_node(uint32_t parentId, uint32_t childId)
     if (parentId == childId)
         return true;
 
-    PostgresStrings<2> parms;
-    parms.set(0, parentId);
-    parms.set(1, childId);
-
     check_postgres();
-    PGresultRef result = PQexecParams(s_postgres,
-                                      "SELECT vault.has_node($1, $2)",
-                                      2, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT vault.has_node($1, $2)",
+            parentId, childId);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -956,7 +927,7 @@ bool v_update_node(const DS::Vault::Node& node)
     /* This should be plenty to store everything we need without a bunch
      * of dynamic reallocations
      */
-    PostgresStrings<32> parms;
+    DS::PostgresStrings<32> parms;
     char fieldbuf[1024];
 
     size_t parmcount = 1;
@@ -967,7 +938,7 @@ bool v_update_node(const DS::Vault::Node& node)
             parms.set(parmcount++, value); \
             fieldp += sprintf(fieldp, "\"" #name "\"=$%zu,", parmcount); \
         }
-    int now = time(0);
+    int now = static_cast<int>(time(nullptr));
     SET_FIELD(ModifyTime, now);
     if (node.has_CreateAgeName())
         SET_FIELD(CreateAgeName, node.m_CreateAgeName);
@@ -1029,7 +1000,7 @@ bool v_update_node(const DS::Vault::Node& node)
         SET_FIELD(Blob_2, ST::base64_encode(node.m_Blob_2.buffer(), node.m_Blob_2.size()));
     #undef SET_FIELD
 
-    DS_DASSERT(fieldp - fieldbuf < 1024);
+    DS_DASSERT(fieldp < fieldbuf + sizeof(fieldbuf));
     *(fieldp - 1) = 0;  // Get rid of the last comma
     ST::string_stream queryStr;
     queryStr << "UPDATE vault.\"Nodes\"\n    SET ";
@@ -1038,8 +1009,9 @@ bool v_update_node(const DS::Vault::Node& node)
     parms.set(0, node.m_NodeIdx);
 
     check_postgres();
-    PGresultRef result = PQexecParams(s_postgres, queryStr.to_string().c_str(),
-                                      parmcount, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = PQexecParams(s_postgres, queryStr.to_string().c_str(),
+                                          parmcount, nullptr, parms.m_values,
+                                          nullptr, nullptr, 0);
     if (PQresultStatus(result) != PGRES_COMMAND_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres UPDATE error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1050,9 +1022,7 @@ bool v_update_node(const DS::Vault::Node& node)
 
 DS::Vault::Node v_fetch_node(uint32_t nodeIdx)
 {
-    PostgresStrings<1> parm;
-    parm.set(0, nodeIdx);
-    PGresultRef result = PQexecParams(s_postgres,
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
         "SELECT idx, \"CreateTime\", \"ModifyTime\", \"CreateAgeName\","
         "    \"CreateAgeUuid\", \"CreatorUuid\", \"CreatorIdx\", \"NodeType\","
         "    \"Int32_1\", \"Int32_2\", \"Int32_3\", \"Int32_4\","
@@ -1062,7 +1032,7 @@ DS::Vault::Node v_fetch_node(uint32_t nodeIdx)
         "    \"String64_5\", \"String64_6\", \"IString64_1\", \"IString64_2\","
         "    \"Text_1\", \"Text_2\", \"Blob_1\", \"Blob_2\""
         "    FROM vault.\"Nodes\" WHERE idx=$1",
-        1, 0, parm.m_values, 0, 0, 0);
+        nodeIdx);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1140,15 +1110,11 @@ DS::Vault::Node v_fetch_node(uint32_t nodeIdx)
 
 bool v_ref_node(uint32_t parentIdx, uint32_t childIdx, uint32_t ownerIdx)
 {
-    PostgresStrings<3> parms;
-    parms.set(0, parentIdx);
-    parms.set(1, childIdx);
-    parms.set(2, ownerIdx);
-    PGresultRef result = PQexecParams(s_postgres,
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "INSERT INTO vault.\"NodeRefs\""
             "    (\"ParentIdx\", \"ChildIdx\", \"OwnerIdx\")"
             "    VALUES ($1, $2, $3)",
-            3, 0, parms.m_values, 0, 0, 0);
+            parentIdx, childIdx, ownerIdx);
     if (PQresultStatus(result) != PGRES_COMMAND_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1159,13 +1125,10 @@ bool v_ref_node(uint32_t parentIdx, uint32_t childIdx, uint32_t ownerIdx)
 
 bool v_unref_node(uint32_t parentIdx, uint32_t childIdx)
 {
-    PostgresStrings<2> parms;
-    parms.set(0, parentIdx);
-    parms.set(1, childIdx);
-    PGresultRef result = PQexecParams(s_postgres,
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "DELETE FROM vault.\"NodeRefs\""
             "    WHERE \"ParentIdx\"=$1 AND \"ChildIdx\"=$2",
-            2, 0, parms.m_values, 0, 0, 0);
+            parentIdx, childIdx);
     if (PQresultStatus(result) != PGRES_COMMAND_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres DELETE error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1176,12 +1139,10 @@ bool v_unref_node(uint32_t parentIdx, uint32_t childIdx)
 
 bool v_fetch_tree(uint32_t nodeId, std::vector<DS::Vault::NodeRef>& refs)
 {
-    PostgresStrings<1> parm;
-    parm.set(0, nodeId);
-    PGresultRef result = PQexecParams(s_postgres,
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "SELECT \"ParentIdx\", \"ChildIdx\", \"OwnerIdx\", \"Seen\""
             "    FROM vault.fetch_tree($1);",
-            1, 0, parm.m_values, 0, 0, 0);
+            nodeId);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1206,7 +1167,7 @@ bool v_find_nodes(const DS::Vault::Node& nodeTemplate, std::vector<uint32_t>& no
     /* This should be plenty to store everything we need without a bunch
      * of dynamic reallocations
      */
-    PostgresStrings<31> parms;
+    DS::PostgresStrings<31> parms;
     char fieldbuf[1024];
 
     size_t parmcount = 0;
@@ -1288,15 +1249,16 @@ bool v_find_nodes(const DS::Vault::Node& nodeTemplate, std::vector<uint32_t>& no
     #undef SET_FIELD_I
 
     DS_DASSERT(parmcount > 0);
-    DS_DASSERT(fieldp - fieldbuf < 1024);
+    DS_DASSERT(fieldp < fieldbuf + sizeof(fieldbuf));
     *(fieldp - 5) = 0;  // Get rid of the last ' AND '
     ST::string_stream queryStr;
     queryStr << "SELECT idx FROM vault.\"Nodes\"\n    WHERE ";
     queryStr << fieldbuf;
 
     check_postgres();
-    PGresultRef result = PQexecParams(s_postgres, queryStr.to_string().c_str(),
-                                      parmcount, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = PQexecParams(s_postgres, queryStr.to_string().c_str(),
+                                          parmcount, nullptr, parms.m_values,
+                                          nullptr, nullptr, 0);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1313,12 +1275,9 @@ DS::Vault::NodeRef v_send_node(uint32_t nodeId, uint32_t playerId, uint32_t send
 {
     DS::Vault::NodeRef ref;
     ref.m_child = ref.m_owner = ref.m_parent = 0;
-    PostgresStrings<2> parms;
-    parms.set(0, playerId);
-    parms.set(1, DS::Vault::e_InboxFolder);
-    PGresultRef result = PQexecParams(s_postgres,
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
             "SELECT idx FROM vault.find_folder($1, $2);",
-            2, 0, parms.m_values, 0, 0, 0);
+            playerId, DS::Vault::e_InboxFolder);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
@@ -1337,22 +1296,19 @@ DS::Vault::NodeRef v_send_node(uint32_t nodeId, uint32_t playerId, uint32_t send
 
 uint32_t v_count_age_owners(uint32_t ageInfoId)
 {
-    PostgresStrings<2> parms;
-    parms.set(0, ageInfoId);
-    parms.set(1, DS::Vault::e_AgeOwnersFolder);
-    PGresultRef result = PQexecParams(s_postgres,
-                         "SELECT idx FROM vault.find_folder($1, $2);",
-                         2, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT idx FROM vault.find_folder($1, $2);",
+            ageInfoId, DS::Vault::e_AgeOwnersFolder);
     uint32_t owners = 0;
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
         return owners;
     }
-    parms.set(0, PQgetvalue(result, 0, 0));
-    result = PQexecParams(s_postgres,
-             "SELECT COUNT(*) FROM vault.\"NodeRefs\" WHERE \"ParentIdx\"=$1",
-              1, 0, parms.m_values, 0, 0, 0);
+    const ST::string parentIdx = PQgetvalue(result, 0, 0);
+    result = DS::PQexecVA(s_postgres,
+            "SELECT COUNT(*) FROM vault.\"NodeRefs\" WHERE \"ParentIdx\"=$1",
+            parentIdx);
     if (PQresultStatus(result) == PGRES_TUPLES_OK) {
         owners = strtoul(PQgetvalue(result, 0, 0), 0, 10);
     } else {
@@ -1364,13 +1320,10 @@ uint32_t v_count_age_owners(uint32_t ageInfoId)
 
 uint32_t v_count_age_population(const char* uuid)
 {
-    PostgresStrings<2> parms;
-    parms.set(0, DS::Vault::e_NodePlayerInfo);
-    parms.set(1, uuid);
-    PGresultRef result = PQexecParams(s_postgres,
-                         "SELECT COUNT(*) FROM vault.\"Nodes\" WHERE \"NodeType\"=$1 AND"
-                         "    \"Int32_1\"=1 AND \"Uuid_1\"=$2",
-                         2, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT COUNT(*) FROM vault.\"Nodes\" WHERE \"NodeType\"=$1 AND"
+            "    \"Int32_1\"=1 AND \"Uuid_1\"=$2",
+            DS::Vault::e_NodePlayerInfo, uuid);
     uint32_t population = 0;
     if (PQresultStatus(result) == PGRES_TUPLES_OK) {
         population = strtoul(PQgetvalue(result, 0, 0), 0, 10);
@@ -1383,16 +1336,13 @@ uint32_t v_count_age_population(const char* uuid)
 
 bool v_find_public_ages(const ST::string& ageFilename, std::vector<Auth_PubAgeRequest::NetAgeInfo>& ages)
 {
-    PostgresStrings<2> parms;
-    parms.set(0, DS::Vault::e_NodeAgeInfo);
-    parms.set(1, ageFilename);
     // ageInfoId, Uuid, InstName, UserName, Description, SeqNumber, Language
-    PGresultRef result = PQexecParams(s_postgres,
-                         "SELECT idx, \"Uuid_1\", \"String64_3\", \"String64_4\","
-                         "    \"Text_1\",\"Int32_1\", \"Int32_3\" FROM vault.\"Nodes\""
-                         "    WHERE \"NodeType\"=$1 AND \"Int32_2\"=1 AND \"String64_2\"=$2"
-                         "    ORDER BY \"ModifyTime\" DESC LIMIT 50",
-                         2, 0, parms.m_values, 0, 0, 0);
+    DS::PGresultRef result = DS::PQexecVA(s_postgres,
+            "SELECT idx, \"Uuid_1\", \"String64_3\", \"String64_4\","
+            "    \"Text_1\",\"Int32_1\", \"Int32_3\" FROM vault.\"Nodes\""
+            "    WHERE \"NodeType\"=$1 AND \"Int32_2\"=1 AND \"String64_2\"=$2"
+            "    ORDER BY \"ModifyTime\" DESC LIMIT 50",
+            DS::Vault::e_NodeAgeInfo, ageFilename);
     if (PQresultStatus(result) != PGRES_TUPLES_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres SELECT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));

--- a/AuthServ/VaultTypes.cpp
+++ b/AuthServ/VaultTypes.cpp
@@ -21,7 +21,8 @@
 #define READ_VAULT_STRING(value) \
     { \
         uint32_t length = stream->read<uint32_t>(); \
-        DS_PASSERT((length % sizeof(char16_t)) == 0); \
+        if ((length % sizeof(char16_t)) != 0) \
+            throw DS::MalformedData(); \
         ST::utf16_buffer storage; \
         char16_t* buffer = storage.create_writable_buffer(length / sizeof(char16_t)); \
         stream->readBytes(buffer, length); \

--- a/FileServ/FileManifest.cpp
+++ b/FileServ/FileManifest.cpp
@@ -99,6 +99,10 @@ uint32_t DS::FileManifest::encodeToStream(DS::Stream* stream) const
     }
     stream->write<uint16_t>(0);
 
-    DS_DASSERT((stream->tell() - start) % sizeof(char16_t) == 0);
+    if ((stream->tell() - start) % sizeof(char16_t) != 0) {
+        fputs("WARNING: Encoded manifest data was not evenly divisible by "
+              "UTF-16 character size.  The recipient client may crash...\n",
+              stderr);
+    }
     return (stream->tell() - start) / sizeof(char16_t);
 }

--- a/FileServ/FileServer.cpp
+++ b/FileServ/FileServer.cpp
@@ -332,14 +332,11 @@ void wk_fileServ(DS::SocketHandle sockp)
                 throw DS::SockHup();
             }
         }
-    } catch (const DS::AssertException& ex) {
-        fprintf(stderr, "[File] Assertion failed at %s:%ld:  %s\n",
-                ex.m_file, ex.m_line, ex.m_cond);
-    } catch (const DS::PacketSizeOutOfBounds& ex) {
-        fprintf(stderr, "[File] Client packet size too large: Requested %u bytes\n",
-                ex.requestedSize());
     } catch (const DS::SockHup&) {
         // Socket closed...
+    } catch (const std::exception& ex) {
+        fprintf(stderr, "[File] Error processing client message from %s: %s\n",
+                DS::SockIpAddress(sockp).c_str(), ex.what());
     }
 
     s_clientMutex.lock();

--- a/FileServ/FileServer.cpp
+++ b/FileServ/FileServer.cpp
@@ -107,7 +107,8 @@ void file_init(FileServer_Private& client)
 {
     /* File server header:  size, buildId, serverType */
     uint32_t size = DS::RecvValue<uint32_t>(client.m_sock);
-    DS_PASSERT(size == 12);
+    if (size != 12)
+        throw DS::InvalidConnectionHeader();
     DS::RecvValue<uint32_t>(client.m_sock);
     DS::RecvValue<uint32_t>(client.m_sock);
 }

--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -57,13 +57,6 @@ agemap_t s_ages;
     DM_WRITEBUF(msg); \
     client->m_broadcast.putMessage(e_GameToCli_PropagateBuffer, _msgbuf)
 
-static inline void check_postgres(GameHost_Private* host)
-{
-    if (PQstatus(host->m_postgres) == CONNECTION_BAD)
-        PQreset(host->m_postgres);
-    DS_DASSERT(PQstatus(host->m_postgres) == CONNECTION_OK);
-}
-
 void dm_game_shutdown(GameHost_Private* host)
 {
     {
@@ -325,7 +318,7 @@ void dm_game_join(GameHost_Private* host, Game_ClientMessage* msg)
 
 void dm_send_state(GameHost_Private* host, GameClient_Private* client)
 {
-    check_postgres(host);
+    check_postgres(host->m_postgres);
 
     MOUL::NetMsgSDLState* state = MOUL::NetMsgSDLState::Create();
     state->m_contentFlags = MOUL::NetMessage::e_HasTimeSent
@@ -376,7 +369,7 @@ void dm_send_state(GameHost_Private* host, GameClient_Private* client)
 void dm_save_sdl_state(GameHost_Private* host, const ST::string& descriptor,
                        const MOUL::Uoid& object, const SDL::State& state)
 {
-    check_postgres(host);
+    check_postgres(host->m_postgres);
 
     DS::Blob sdlBlob = state.toBlob();
     DS::BufferStream buffer;

--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -777,8 +777,9 @@ void dm_global_sdl_update(GameHost_Private* host)
 void dm_gameHost(GameHost_Private* host)
 {
     for ( ;; ) {
-        DS::FifoMessage msg = host->m_channel.getMessage();
+        DS::FifoMessage msg { -1, nullptr };
         try {
+            msg = host->m_channel.getMessage();
             switch (msg.m_messageType) {
             case e_GameShutdown:
                 dm_game_shutdown(host);

--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -817,7 +817,7 @@ void dm_gameHost(GameHost_Private* host)
     }
 
     // This line should be unreachable
-    DS_PASSERT(false);
+    DS_ASSERT(false);
 }
 
 GameHost_Private* start_game_host(uint32_t ageMcpId)

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -188,7 +188,7 @@ void cb_sockRead(GameClient_Private& client)
     case e_CliToGame_JoinAgeRequest:
         cb_join(client);
         break;
-    case e_CliToGame_Propagatebuffer:
+    case e_CliToGame_PropagateBuffer:
         DS_PASSERT(client.m_host != 0);
         cb_netmsg(client);
         break;

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -254,14 +254,11 @@ void wk_gameWorker(DS::SocketHandle sockp)
             if (fds[1].revents & POLLIN)
                 cb_broadcast(client);
         }
-    } catch (const DS::AssertException& ex) {
-        fprintf(stderr, "[Game] Assertion failed at %s:%ld:  %s\n",
-                ex.m_file, ex.m_line, ex.m_cond);
-    } catch (const DS::PacketSizeOutOfBounds& ex) {
-        fprintf(stderr, "[Game] Client packet size too large: Requested %u bytes\n",
-                ex.requestedSize());
     } catch (const DS::SockHup&) {
         // Socket closed...
+    } catch (const std::exception& ex) {
+        fprintf(stderr, "[Game] Error processing client message from %s: %s\n",
+                DS::SockIpAddress(sockp).c_str(), ex.what());
     }
 
     if (client.m_host) {

--- a/GameServ/GameServer_Private.h
+++ b/GameServ/GameServer_Private.h
@@ -34,7 +34,7 @@
 enum GameServer_MsgIds
 {
     e_CliToGame_PingRequest = 0, e_CliToGame_JoinAgeRequest,
-    e_CliToGame_Propagatebuffer, e_CliToGame_GameMgrMsg,
+    e_CliToGame_PropagateBuffer, e_CliToGame_GameMgrMsg,
 
     e_GameToCli_PingReply = 0, e_GameToCli_JoinAgeReply,
     e_GameToCli_PropagateBuffer, e_GameToCli_GameMgrMsg,

--- a/GateKeeper/GateServ.cpp
+++ b/GateKeeper/GateServ.cpp
@@ -59,7 +59,8 @@ void gate_init(GateKeeper_Private& client)
 {
     /* Gate Keeper header:  size, null uuid */
     uint32_t size = DS::RecvValue<uint32_t>(client.m_sock);
-    DS_PASSERT(size == 20);
+    if (size != 20)
+        throw DS::InvalidConnectionHeader();
     DS::Uuid uuid;
     DS::RecvBuffer(client.m_sock, uuid.m_bytes, sizeof(uuid.m_bytes));
 
@@ -69,7 +70,8 @@ void gate_init(GateKeeper_Private& client)
 
     /* Establish encryption, and write reply body */
     uint8_t msgId = DS::RecvValue<uint8_t>(client.m_sock);
-    DS_PASSERT(msgId == DS::e_CliToServConnect);
+    if (msgId != DS::e_CliToServConnect)
+        throw DS::InvalidConnectionHeader();
     uint8_t msgSize = DS::RecvValue<uint8_t>(client.m_sock);
     if (msgSize == 2) {
         // no seed... client wishes unencrypted connection (that's okay, nobody
@@ -79,7 +81,8 @@ void gate_init(GateKeeper_Private& client)
     } else {
         uint8_t Y[64];
         memset(Y, 0, sizeof(Y));
-        DS_PASSERT(msgSize <= 66);
+        if (msgSize > 66)
+            throw DS::InvalidConnectionHeader();
         DS::RecvBuffer(client.m_sock, Y, 64 - (66 - msgSize));
         BYTE_SWAP_BUFFER(Y, 64);
 

--- a/GateKeeper/GateServ.cpp
+++ b/GateKeeper/GateServ.cpp
@@ -185,14 +185,11 @@ void wk_gateKeeper(DS::SocketHandle sockp)
                 throw DS::SockHup();
             }
         }
-    } catch (const DS::AssertException& ex) {
-        fprintf(stderr, "[GateKeeper] Assertion failed at %s:%ld:  %s\n",
-                ex.m_file, ex.m_line, ex.m_cond);
-    } catch (const DS::PacketSizeOutOfBounds& ex) {
-        fprintf(stderr, "[GateKeeper] Client packet size too large: Requested %u bytes\n",
-                ex.requestedSize());
     } catch (const DS::SockHup&) {
         // Socket closed...
+    } catch (const std::exception& ex) {
+        fprintf(stderr, "[GateKeeper] Error processing client message from %s: %s\n",
+                DS::SockIpAddress(sockp).c_str(), ex.what());
     }
 
     s_clientMutex.lock();

--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -116,7 +116,7 @@ void DS::CryptEstablish(uint8_t* seed, uint8_t* key, const uint8_t* N,
     BN_bin2bn(reinterpret_cast<const unsigned char*>(Y), 64, bn_Y);
     BN_bin2bn(reinterpret_cast<const unsigned char*>(N), 64, bn_N);
     BN_bin2bn(reinterpret_cast<const unsigned char*>(K), 64, bn_K);
-    DS_PASSERT(!BN_is_zero(bn_N));
+    DS_ASSERT(!BN_is_zero(bn_N));
     BN_mod_exp(bn_seed, bn_Y, bn_K, bn_N, ctx);
 
     /* Apply server seed for establishing crypt state with client */

--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -121,7 +121,8 @@ void DS::CryptEstablish(uint8_t* seed, uint8_t* key, const uint8_t* N,
 
     /* Apply server seed for establishing crypt state with client */
     uint8_t keybuf[64];
-    DS_DASSERT(BN_num_bytes(bn_seed) <= 64);
+    if (BN_num_bytes(bn_seed) > 64)
+        throw DS::InvalidConnectionHeader();
     size_t outBytes = BN_bn2bin(bn_seed, reinterpret_cast<unsigned char*>(keybuf));
     BYTE_SWAP_BUFFER(keybuf, outBytes);
     for (size_t i=0; i<7; ++i)

--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -43,7 +43,11 @@ static void init_rand()
         _random.mypid = getpid();
         gettimeofday(&_random.now, 0);
         FILE* urand = fopen("/dev/urandom", "rb");
-        DS_PASSERT(urand != 0);
+        if (!urand) {
+            fprintf(stderr, "FATAL: Could not open /dev/urandom: %s\n",
+                    strerror(errno));
+            exit(1);
+        }
         fread(_random.buffer, 1, sizeof(_random.buffer), urand);
         fclose(urand);
         RAND_seed(&_random, sizeof(_random));

--- a/NetIO/Lobby.cpp
+++ b/NetIO/Lobby.cpp
@@ -50,7 +50,7 @@ static DS::SocketHandle s_listenSock;
 void dm_lobby()
 {
     printf("[Lobby] Running on %s\n", DS::SockIpAddress(s_listenSock).c_str());
-    try {
+    {
         for ( ;; ) {
             DS::SocketHandle client;
             try {
@@ -98,11 +98,12 @@ void dm_lobby()
                 }
             } catch (const DS::SockHup& hup) {
                 DS::FreeSock(client);
+            } catch (const std::exception& ex) {
+                fprintf(stderr, "[Lobby] %s - Exception while processing incoming client: %s\n",
+                        DS::SockIpAddress(client).c_str(), ex.what());
+                DS::FreeSock(client);
             }
         }
-    } catch (const DS::AssertException& ex) {
-        fprintf(stderr, "[Lobby] Assertion failed at %s:%ld:  %s\n",
-                ex.m_file, ex.m_line, ex.m_cond);
     }
 
     DS::FreeSock(s_listenSock);

--- a/NetIO/MsgChannel.cpp
+++ b/NetIO/MsgChannel.cpp
@@ -15,29 +15,35 @@
  * along with dirtsand.  If not, see <http://www.gnu.org/licenses/>.          *
  ******************************************************************************/
 
+#include "MsgChannel.h"
+
 #include <sys/eventfd.h>
 #include <unistd.h>
 #include <errno.h>
 #include <cstring>
-#include "MsgChannel.h"
-
-DS::MsgChannel::MsgChannel()
-{
-    m_semaphore = eventfd(0, EFD_SEMAPHORE);
-    if (m_semaphore < 0) {
-        fprintf(stderr, "FATAL: Failed to create event semaphore: %s\n",
-                strerror(errno));
-        exit(1);
-    }
-}
+#include "errors.h"
 
 DS::MsgChannel::~MsgChannel()
 {
+    if (m_semaphore < 0)
+        return;
+
     int result = close(m_semaphore);
     if (result < 0 && errno != EBADF) {
         fprintf(stderr, "WARNING: Failed to close event semaphore: %s\n",
                 strerror(errno));
     }
+}
+
+int DS::MsgChannel::fd()
+{
+    if (m_semaphore >= 0)
+        return m_semaphore;
+
+    m_semaphore = eventfd(0, EFD_SEMAPHORE);
+    if (m_semaphore < 0)
+        throw SystemError("Failed to create event semaphore", strerror(errno));
+    return m_semaphore;
 }
 
 void DS::MsgChannel::putMessage(int type, void* payload)
@@ -49,23 +55,17 @@ void DS::MsgChannel::putMessage(int type, void* payload)
     m_queue.push(msg);
     m_queueMutex.unlock();
 
-    int result = eventfd_write(m_semaphore, 1);
-    if (result < 0) {
-        fprintf(stderr, "FATAL: Failed to write to event semaphore: %s\n",
-                strerror(errno));
-        exit(1);
-    }
+    int result = eventfd_write(fd(), 1);
+    if (result < 0)
+        throw SystemError("Failed to write to event semaphore", strerror(errno));
 }
 
 DS::FifoMessage DS::MsgChannel::getMessage()
 {
     eventfd_t value;
-    int result = eventfd_read(m_semaphore, &value);
-    if (result < 0) {
-        fprintf(stderr, "FATAL: Failed to read from event semaphore: %s\n",
-                strerror(errno));
-        exit(1);
-    }
+    int result = eventfd_read(fd(), &value);
+    if (result < 0)
+        throw SystemError("Failed to read from event semaphore", strerror(errno));
 
     m_queueMutex.lock();
     FifoMessage msg = m_queue.front();

--- a/NetIO/MsgChannel.h
+++ b/NetIO/MsgChannel.h
@@ -33,7 +33,7 @@ namespace DS
     {
     public:
         MsgChannel();
-        ~MsgChannel() noexcept(false);
+        ~MsgChannel();
 
         int fd() const { return m_semaphore; }
         void putMessage(int type, void* payload = 0);

--- a/NetIO/MsgChannel.h
+++ b/NetIO/MsgChannel.h
@@ -32,10 +32,10 @@ namespace DS
     class MsgChannel
     {
     public:
-        MsgChannel();
+        MsgChannel() : m_semaphore(-1) { }
         ~MsgChannel();
 
-        int fd() const { return m_semaphore; }
+        int fd();
         void putMessage(int type, void* payload = 0);
         FifoMessage getMessage();
         bool hasMessage();

--- a/NetIO/SockIO.cpp
+++ b/NetIO/SockIO.cpp
@@ -127,7 +127,7 @@ DS::SocketHandle DS::BindSocket(const char* address, const char* port)
 
 void DS::ListenSock(const DS::SocketHandle sock, int backlog)
 {
-    DS_DASSERT(sock);
+    DS_ASSERT(sock);
     int result = listen(reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd, backlog);
     if (result < 0) {
         const char *error_text = strerror(errno);
@@ -139,7 +139,7 @@ void DS::ListenSock(const DS::SocketHandle sock, int backlog)
 
 DS::SocketHandle DS::AcceptSock(const DS::SocketHandle sock)
 {
-    DS_DASSERT(sock);
+    DS_ASSERT(sock);
     SocketHandle_Private* sockp = reinterpret_cast<SocketHandle_Private*>(sock);
 
     SocketHandle_Private* client = new SocketHandle_Private();

--- a/NetIO/SockIO.cpp
+++ b/NetIO/SockIO.cpp
@@ -153,7 +153,7 @@ DS::SocketHandle DS::AcceptSock(const DS::SocketHandle sock)
         } else {
             fprintf(stderr, "Failed to accept incoming connection: %s\n",
                     strerror(errno));
-            exit(1);
+            return nullptr;
         }
     }
     timeval tv;
@@ -167,7 +167,10 @@ DS::SocketHandle DS::AcceptSock(const DS::SocketHandle sock)
 
 void DS::CloseSock(DS::SocketHandle sock)
 {
-    DS_DASSERT(sock);
+    if (!sock) {
+        fputs("WARNING: Tried to close invalid socket\n", stderr);
+        return;
+    }
     shutdown(reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd, SHUT_RDWR);
     close(reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd);
 }
@@ -182,7 +185,11 @@ ST::string DS::SockIpAddress(const DS::SocketHandle sock)
 {
     char addrbuf[256];
     SocketHandle_Private* sockp = reinterpret_cast<SocketHandle_Private*>(sock);
-    inet_ntop(sockp->m_addr.sa_family, get_in_addr(sockp), addrbuf, 256);
+    if (!inet_ntop(sockp->m_addr.sa_family, get_in_addr(sockp), addrbuf, 256)) {
+        fprintf(stderr, "Failed to get socket address: %s\n",
+                strerror(errno));
+        return ST_LITERAL("???");
+    }
     return ST::format("{}/{}", addrbuf, get_in_port(sockp));
 }
 
@@ -195,9 +202,21 @@ uint32_t DS::GetAddress4(const char* lookup)
     info.ai_flags = 0;
 
     addrinfo* addrList;
-    int result = getaddrinfo(lookup, 0, &info, &addrList);
-    DS_PASSERT(result == 0);
-    DS_PASSERT(addrList != 0);
+    int result = getaddrinfo(lookup, nullptr, &info, &addrList);
+    if (result != 0) {
+        if (result == EAI_SYSTEM) {
+            fprintf(stderr, "WARNING: Failed to get address of %s: %s\n",
+                    lookup, strerror(errno));
+        } else {
+            fprintf(stderr, "WARNING: Failed to get address of %s: %s\n",
+                    lookup, gai_strerror(result));
+        }
+        return 0;
+    }
+    if (!addrList) {
+        fprintf(stderr, "WARNING: No address info found for %s\n", lookup);
+        return 0;
+    }
     uint32_t addr = reinterpret_cast<sockaddr_in*>(addrList->ai_addr)->sin_addr.s_addr;
     freeaddrinfo(addrList);
 
@@ -215,21 +234,20 @@ void DS::SendBuffer(const DS::SocketHandle sock, const void* buffer, size_t size
         ssize_t bytes = send(reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd,
                              buffer, size, 0);
         if (bytes < 0) {
-            if (errno == EPIPE || errno == ECONNRESET)
-                throw DS::SockHup();
+            if (errno != EPIPE && errno != ECONNRESET) {
+                const char *error_text = strerror(errno);
+                fprintf(stderr, "Failed to send to %s: %s\n",
+                        DS::SockIpAddress(sock).c_str(), error_text);
+            }
+            throw DS::SockHup();
         } else if (bytes == 0) {
+            // Connection closed without error
             throw DS::SockHup();
         }
-        DS_PASSERT(bytes > 0);
 
         size -= bytes;
         buffer = reinterpret_cast<const void*>(reinterpret_cast<const uint8_t*>(buffer) + bytes);
     } while (size > 0);
-
-    if (size > 0) {
-        CloseSock(sock);
-        throw DS::SockHup();
-    }
 }
 
 void DS::SendFile(const DS::SocketHandle sock, const void* buffer, size_t bufsz,
@@ -241,11 +259,17 @@ void DS::SendFile(const DS::SocketHandle sock, const void* buffer, size_t bufsz,
     setsockopt(imp->m_sockfd, IPPROTO_TCP, TCP_CORK, &SOCK_YES, sizeof(SOCK_YES));
     while (bufsz > 0) {
         ssize_t bytes = send(imp->m_sockfd, buffer, bufsz, 0);
-        if (bytes < 0 && (errno == EPIPE || errno == ECONNRESET))
+        if (bytes < 0) {
+            if (errno != EPIPE && errno != ECONNRESET) {
+                const char *error_text = strerror(errno);
+                fprintf(stderr, "Failed to send to %s: %s\n",
+                        DS::SockIpAddress(sock).c_str(), error_text);
+            }
             throw DS::SockHup();
-        else if (bytes == 0)
+        } else if (bytes == 0) {
+            // Connection closed without error
             throw DS::SockHup();
-        DS_PASSERT(bytes > 0);
+        }
 
         bufsz -= bytes;
         buffer = reinterpret_cast<const void*>(reinterpret_cast<const uint8_t*>(buffer) + bytes);
@@ -254,13 +278,18 @@ void DS::SendFile(const DS::SocketHandle sock, const void* buffer, size_t bufsz,
     // Now send the file data via a system call
     while (fdsz > 0) {
         ssize_t bytes = sendfile(imp->m_sockfd, fd, offset, fdsz);
-        if (bytes < 0 && (errno == EAGAIN))
-            continue;
-        else if (bytes < 0 && (errno == EPIPE || errno == ECONNRESET))
+        if (bytes < 0) {
+            if (errno == EAGAIN) {
+                continue;
+            } else if (errno != EPIPE && errno != ECONNRESET) {
+                const char *error_text = strerror(errno);
+                fprintf(stderr, "Failed to send to %s: %s\n",
+                        DS::SockIpAddress(sock).c_str(), error_text);
+            }
             throw DS::SockHup();
-        else if (bytes == 0)
+        } else if (bytes == 0) {
             throw DS::SockHup();
-        DS_PASSERT(bytes > 0);
+        }
         fdsz -= bytes;
     }
     setsockopt(imp->m_sockfd, IPPROTO_TCP, TCP_CORK, &SOCK_NO, sizeof(SOCK_NO));
@@ -271,13 +300,19 @@ void DS::RecvBuffer(const DS::SocketHandle sock, void* buffer, size_t size)
     while (size > 0) {
         ssize_t bytes = recv(reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd,
                              buffer, size, 0);
-        if (bytes < 0 && (errno == ECONNRESET || errno == EAGAIN || errno == EWOULDBLOCK || errno == EPIPE))
+        if (bytes < 0) {
+            if (errno == EINTR) {
+                continue;
+            } else if (errno != ECONNRESET && errno != EAGAIN
+                       && errno != EWOULDBLOCK && errno != EPIPE) {
+                const char *error_text = strerror(errno);
+                fprintf(stderr, "Failed to recv from %s: %s\n",
+                        DS::SockIpAddress(sock).c_str(), error_text);
+            }
             throw DS::SockHup();
-        if (bytes < 0 && errno == EINTR)
-            continue;
-        else if (bytes == 0)
+        } else if (bytes == 0) {
             throw DS::SockHup();
-        DS_PASSERT(bytes > 0);
+        }
 
         size -= bytes;
         buffer = reinterpret_cast<void*>(reinterpret_cast<uint8_t*>(buffer) + bytes);
@@ -290,11 +325,16 @@ size_t DS::PeekSize(const SocketHandle sock)
     ssize_t bytes = recv(reinterpret_cast<SocketHandle_Private*>(sock)->m_sockfd,
                          buffer, 256, MSG_PEEK | MSG_TRUNC);
 
-    if (bytes < 0 && (errno == ECONNRESET || errno == EAGAIN || errno == EWOULDBLOCK))
+    if (bytes < 0) {
+        if (errno != ECONNRESET && errno != EAGAIN && errno != EWOULDBLOCK) {
+            const char *error_text = strerror(errno);
+            fprintf(stderr, "Failed to peek from %s: %s\n",
+                    DS::SockIpAddress(sock).c_str(), error_text);
+        }
         throw DS::SockHup();
-    else if (bytes == 0)
+    } else if (bytes == 0) {
         throw DS::SockHup();
-    DS_PASSERT(bytes > 0);
+    }
 
     return static_cast<size_t>(bytes);
 }

--- a/NetIO/SockIO.h
+++ b/NetIO/SockIO.h
@@ -19,7 +19,7 @@
 #define _DS_SOCKIO_H
 
 #include "streams.h"
-#include <exception>
+#include <stdexcept>
 
 // Don't allow the client to send payloads > 128KB in size
 #define MAX_PAYLOAD_SIZE (128 * 1024)
@@ -52,15 +52,12 @@ namespace DS
         return value;
     }
 
-    class PacketSizeOutOfBounds : public std::exception
+    class PacketSizeOutOfBounds : public std::runtime_error
     {
     public:
-        PacketSizeOutOfBounds(uint32_t requestedSize) throw()
-            : m_requestedSize(requestedSize) { }
-        virtual ~PacketSizeOutOfBounds() throw() { }
-
-        virtual const char* what() const throw()
-        { return "Packet size is too large"; }
+        explicit PacketSizeOutOfBounds(uint32_t requestedSize)
+            : std::runtime_error("Packet size is too large"),
+              m_requestedSize(requestedSize) { }
 
         uint32_t requestedSize() const { return m_requestedSize; }
 
@@ -76,14 +73,10 @@ namespace DS
         return size;
     }
 
-    class SockHup : public std::exception
+    class SockHup : public std::runtime_error
     {
     public:
-        SockHup() throw() { }
-        virtual ~SockHup() throw() { }
-
-        virtual const char* what() const throw()
-        { return "Socket closed"; }
+        SockHup() : std::runtime_error("Socket closed") { }
     };
 }
 

--- a/PlasMOUL/AgeLinkStruct.cpp
+++ b/PlasMOUL/AgeLinkStruct.cpp
@@ -81,8 +81,10 @@ void MOUL::AgeInfoStruct::write(DS::Stream* s) const
 void MOUL::AgeLinkStruct::read(DS::Stream* s)
 {
     m_flags = s->read<uint16_t>();
-    DS_PASSERT(!(m_flags & e_HasSpawnPtInline)); // Trolololololololo
-    DS_PASSERT(!(m_flags & e_HasSpawnPtLegacy)); // Ahahahahahahahaha
+    if (m_flags & (e_HasSpawnPtInline | e_HasSpawnPtLegacy)) {
+        // Trolololololololo
+        throw DS::MalformedData();
+    }
 
     if (m_flags & e_HasAgeInfo)
         m_ageInfo->read(s);
@@ -98,9 +100,8 @@ void MOUL::AgeLinkStruct::read(DS::Stream* s)
 
 void MOUL::AgeLinkStruct::write(DS::Stream* s) const
 {
-    DS_PASSERT(!(m_flags & e_HasSpawnPtInline)); // Trolololololololo
-    DS_PASSERT(!(m_flags & e_HasSpawnPtLegacy)); // Ahahahahahahahaha
-    s->write<uint16_t>(m_flags);
+    const uint16_t supportedFlags = m_flags & ~(e_HasSpawnPtLegacy | e_HasSpawnPtInline);
+    s->write<uint16_t>(supportedFlags);
 
     if (m_flags & e_HasAgeInfo)
         m_ageInfo->write(s);

--- a/PlasMOUL/GenericValue.cpp
+++ b/PlasMOUL/GenericValue.cpp
@@ -18,60 +18,6 @@
 #include "GenericValue.h"
 #include "errors.h"
 
-int32_t MOUL::GenericValue::toInt() const
-{
-    DS_PASSERT(m_dataType == e_Int || m_dataType == e_Any);
-    if (m_dataType == e_Any)
-        return m_string.to_int();
-    return m_int;
-}
-
-uint32_t MOUL::GenericValue::toUint() const
-{
-    DS_PASSERT(m_dataType == e_UInt || m_dataType == e_Any);
-    if (m_dataType == e_Any)
-        return m_string.to_uint();
-    return m_uint;
-}
-
-float MOUL::GenericValue::toFloat() const
-{
-    DS_PASSERT(m_dataType == e_Float || m_dataType == e_Any);
-    if (m_dataType == e_Any)
-        return m_string.to_float();
-    return m_float;
-}
-
-double MOUL::GenericValue::toDouble() const
-{
-    DS_PASSERT(m_dataType == e_Double || m_dataType == e_Any);
-    if (m_dataType == e_Any)
-        return m_string.to_double();
-    return m_double;
-}
-
-bool MOUL::GenericValue::toBool() const
-{
-    DS_PASSERT(m_dataType == e_Bool || m_dataType == e_Any);
-    if (m_dataType == e_Any)
-        return m_string.to_bool();
-    return m_bool;
-}
-
-ST::string MOUL::GenericValue::toString() const
-{
-    DS_PASSERT(m_dataType == e_String || m_dataType == e_Any);
-    return m_string;
-}
-
-char MOUL::GenericValue::toChar() const
-{
-    DS_PASSERT(m_dataType == e_Char || m_dataType == e_Any);
-    if (m_dataType == e_Any)
-        return m_string.c_str()[0];
-    return m_char;
-}
-
 void MOUL::GenericValue::read(DS::Stream* stream)
 {
     m_dataType = stream->read<uint8_t>();

--- a/PlasMOUL/GenericValue.h
+++ b/PlasMOUL/GenericValue.h
@@ -43,24 +43,6 @@ namespace MOUL
             e_None = 0xFF,
         };
 
-        void set(int32_t i) { m_int = i; m_dataType = e_Int; }
-        void set(uint32_t i) { m_uint = i; m_dataType = e_UInt; }
-        void set(float f) { m_float = f; m_dataType = e_Float; }
-        void set(double d) { m_double = d; m_dataType = e_Double; }
-        void set(bool b) { m_bool = b; m_dataType = e_Bool; }
-        void set(const ST::string& s) { m_string = s; m_dataType = e_String; }
-        void set(char c) { m_char = c; m_dataType = e_Char; }
-        void setAny(const ST::string& s) { m_string = s; m_dataType = e_Any; }
-        void reset() { m_dataType = e_None; }
-
-        int32_t toInt() const;
-        uint32_t toUint() const;
-        float toFloat() const;
-        double toDouble() const;
-        bool toBool() const;
-        ST::string toString() const;
-        char toChar() const;
-
     protected:
         GenericValue(uint16_t type) : Creatable(type), m_dataType(e_None) { }
 

--- a/PlasMOUL/Messages/CreatableList.cpp
+++ b/PlasMOUL/Messages/CreatableList.cpp
@@ -62,7 +62,8 @@ void MOUL::CreatableList::read(DS::Stream* stream)
         uint16_t id = ram.read<uint16_t>();
         uint16_t type = ram.read<uint16_t>();
         Creatable* cre = Factory::Create(type);
-        DS_PASSERT(cre);
+        if (!cre)
+            throw DS::MalformedData();
         cre->read(&ram);
         m_items[id] = cre;
     }

--- a/PlasMOUL/Messages/CreatableList.cpp
+++ b/PlasMOUL/Messages/CreatableList.cpp
@@ -19,6 +19,7 @@
 #include "factory.h"
 #include "errors.h"
 #include <zlib.h>
+#include <memory>
 
 #define COMPRESSION_THRESHOLD 255
 
@@ -36,27 +37,23 @@ void MOUL::CreatableList::read(DS::Stream* stream)
     m_flags = stream->read<uint8_t>();
 
     uint32_t bufSz = stream->read<uint32_t>();
-    uint8_t* buf = new uint8_t[bufSz];
+    std::unique_ptr<uint8_t[]> buf(new uint8_t[bufSz]);
 
     if (m_flags & e_Compressed) {
         uint32_t zBufSz = stream->read<uint32_t>();
-        uint8_t* zBuf = new uint8_t[zBufSz];
-        stream->readBytes(zBuf, zBufSz);
+        std::unique_ptr<uint8_t[]> zBuf(new uint8_t[zBufSz]);
+        stream->readBytes(zBuf.get(), zBufSz);
         uLongf zLen;
-        int result = uncompress(buf, &zLen, zBuf, zBufSz);
-        delete[] zBuf;
-        if (result != Z_OK) {
-            delete[] buf;
-            DS_PASSERT(0);
-        }
-        DS_PASSERT(zLen == bufSz);
+        int result = uncompress(buf.get(), &zLen, zBuf.get(), zBufSz);
+        if (result != Z_OK || zLen != bufSz)
+            throw DS::MalformedData();
         m_flags &= ~e_Compressed;
     } else {
-        stream->readBytes(buf, bufSz);
+        stream->readBytes(buf.get(), bufSz);
     }
 
     DS::BufferStream ram;
-    ram.steal(buf, bufSz);
+    ram.steal(buf.release(), bufSz);
     uint16_t numItems = ram.read<uint16_t>();
     for (uint16_t i = 0; i < numItems; i++) {
         uint16_t id = ram.read<uint16_t>();
@@ -85,22 +82,19 @@ void MOUL::CreatableList::write(DS::Stream* stream) const
 
     uint32_t bufSz = ram.tell();
     ram.seek(0, SEEK_SET);
-    uint8_t* buf = new uint8_t[bufSz];
-    ram.readBytes(buf, bufSz);
+    std::unique_ptr<uint8_t[]> buf(new uint8_t[bufSz]);
+    ram.readBytes(buf.get(), bufSz);
     uLongf zBufSz;
 
     uint8_t flags = m_flags & ~e_Compressed;
     if (flags & e_WantCompression && bufSz > COMPRESSION_THRESHOLD) {
-        uint8_t* zBuf = new uint8_t[bufSz];
-        int result = compress(zBuf, &zBufSz, buf, bufSz);
-        if (result != Z_OK) {
-            delete[] buf;
-            delete[] zBuf;
-            DS_PASSERT(0);
+        std::unique_ptr<uint8_t[]> zBuf(new uint8_t[bufSz]);
+        int result = compress(zBuf.get(), &zBufSz, buf.get(), bufSz);
+        if (result == Z_OK) {
+            memcpy(buf.get(), zBuf.get(), zBufSz);
+            flags |= e_Compressed;
         }
-        memcpy(buf, zBuf, zBufSz);
-        delete[] zBuf;
-        flags |= e_Compressed;
+        // If compression failed, just write the uncompressed list...
     }
 
     ram.truncate();
@@ -112,7 +106,6 @@ void MOUL::CreatableList::write(DS::Stream* stream) const
         ram.write<uint32_t>(bufSz);
     }
 
-    ram.writeBytes(buf, bufSz);
-    delete[] buf;
+    ram.writeBytes(buf.get(), bufSz);
     stream->writeBytes(ram.buffer(), ram.tell());
 }

--- a/PlasMOUL/Messages/EventData.cpp
+++ b/PlasMOUL/Messages/EventData.cpp
@@ -21,7 +21,8 @@
 MOUL::EventData* MOUL::EventData::Read(DS::Stream* stream)
 {
     EventData* data;
-    switch (stream->read<uint32_t>()) {
+    const uint32_t type = stream->read<uint32_t>();
+    switch (type) {
     case e_EvtCollision:
         data = new CollisionEventData();
         break;
@@ -71,7 +72,8 @@ MOUL::EventData* MOUL::EventData::Read(DS::Stream* stream)
         data = new ClimbingBlockerHitEventData();
         break;
     default:
-        DS_PASSERT(0);
+        fprintf(stderr, "Got unsupported EventData type %u\n", type);
+        throw DS::MalformedData();
     }
 
     try {

--- a/PlasMOUL/NetMessages/NetMessage.cpp
+++ b/PlasMOUL/NetMessages/NetMessage.cpp
@@ -26,8 +26,10 @@ void MOUL::NetMessage::read(DS::Stream* stream)
         m_protocolVerMaj = stream->read<uint8_t>();
         m_protocolVerMin = stream->read<uint8_t>();
 
-        DS_PASSERT(m_protocolVerMaj == NETMSG_PROTOCOL_MAJ);
-        DS_PASSERT(m_protocolVerMin == NETMSG_PROTOCOL_MIN);
+        if (m_protocolVerMaj != NETMSG_PROTOCOL_MAJ
+                || m_protocolVerMin == NETMSG_PROTOCOL_MIN) {
+            throw DS::MalformedData();
+        }
     }
 
     if (m_contentFlags & e_HasTimeSent)

--- a/PlasMOUL/NetMessages/NetMsgObject.cpp
+++ b/PlasMOUL/NetMessages/NetMsgObject.cpp
@@ -18,32 +18,29 @@
 #include "NetMsgObject.h"
 #include "errors.h"
 #include <zlib.h>
+#include <memory>
 
 void MOUL::NetMsgStream::read(DS::Stream* stream)
 {
     uint32_t uncompressedSize = stream->read<uint32_t>();
     m_compression = static_cast<Compression>(stream->read<uint8_t>());
     uint32_t size = stream->read<uint32_t>();
-    uint8_t* buffer = new uint8_t[size];
-    stream->readBytes(buffer, size);
+    std::unique_ptr<uint8_t[]> buffer(new uint8_t[size]);
+    stream->readBytes(buffer.get(), size);
 
     if (m_compression == e_CompressZlib) {
         if (size < 2)
             throw DS::MalformedData();
 
-        uint8_t* zbuf = new uint8_t[uncompressedSize];
+        std::unique_ptr<uint8_t[]> zbuf(new uint8_t[uncompressedSize]);
         uLongf zlength = uncompressedSize - 2;
-        memcpy(zbuf, buffer, 2);
-        int result = uncompress(zbuf + 2, &zlength, buffer + 2, size - 2);
-        if (result != Z_OK) {
-            delete[] zbuf;
-            delete[] buffer;
-            DS_PASSERT(0);
-        }
-        m_stream.steal(zbuf, uncompressedSize);
-        delete[] buffer;
+        memcpy(zbuf.get(), buffer.get(), 2);
+        int result = uncompress(zbuf.get() + 2, &zlength, buffer.get() + 2, size - 2);
+        if (result != Z_OK)
+            throw DS::MalformedData();
+        m_stream.steal(zbuf.release(), uncompressedSize);
     } else {
-        m_stream.steal(buffer, size);
+        m_stream.steal(buffer.release(), size);
     }
 }
 
@@ -57,16 +54,14 @@ void MOUL::NetMsgStream::write(DS::Stream* stream) const
             throw DS::MalformedData();
 
         uLongf zlength = compressBound(m_stream.size() - 2);
-        uint8_t* zbuf = new uint8_t[zlength + 2];
-        memcpy(zbuf, m_stream.buffer(), 2);
-        int result = compress(zbuf + 2, &zlength, m_stream.buffer() + 2, m_stream.size() - 2);
-        if (result != Z_OK) {
-            delete[] zbuf;
-            DS_PASSERT(0);
-        }
+        std::unique_ptr<uint8_t[]> zbuf(new uint8_t[zlength + 2]);
+        memcpy(zbuf.get(), m_stream.buffer(), 2);
+        int result = compress(zbuf.get() + 2, &zlength, m_stream.buffer() + 2,
+                              m_stream.size() - 2);
+        if (result != Z_OK)
+            throw DS::MalformedData();
         stream->write<uint32_t>(zlength + 2);
-        stream->writeBytes(zbuf, zlength + 2);
-        delete[] zbuf;
+        stream->writeBytes(zbuf.get(), zlength + 2);
     } else {
         stream->write<uint32_t>(m_stream.size());
         stream->writeBytes(m_stream.buffer(), m_stream.size());

--- a/PlasMOUL/NetMessages/NetMsgObject.cpp
+++ b/PlasMOUL/NetMessages/NetMsgObject.cpp
@@ -28,7 +28,8 @@ void MOUL::NetMsgStream::read(DS::Stream* stream)
     stream->readBytes(buffer, size);
 
     if (m_compression == e_CompressZlib) {
-        DS_PASSERT(size >= 2);
+        if (size < 2)
+            throw DS::MalformedData();
 
         uint8_t* zbuf = new uint8_t[uncompressedSize];
         uLongf zlength = uncompressedSize - 2;
@@ -52,7 +53,8 @@ void MOUL::NetMsgStream::write(DS::Stream* stream) const
     stream->write<uint8_t>(m_compression);
 
     if (m_compression == e_CompressZlib) {
-        DS_PASSERT(m_stream.size() >= 2);
+        if (m_stream.size() < 2)
+            throw DS::MalformedData();
 
         uLongf zlength = compressBound(m_stream.size() - 2);
         uint8_t* zbuf = new uint8_t[zlength + 2];

--- a/PlasMOUL/NetMessages/NetMsgSharedState.cpp
+++ b/PlasMOUL/NetMessages/NetMsgSharedState.cpp
@@ -101,7 +101,11 @@ void MOUL::NetMsgSharedState::read(DS::Stream* stream)
 
     for (size_t i=0; i<m_vars.size(); ++i)
         m_vars[i].read(&msgStream.m_stream);
-    DS_DASSERT(msgStream.m_stream.atEof());
+    if (!msgStream.m_stream.atEof()) {
+        fprintf(stderr, "WARNING: %u bytes left over in stream after parsing "
+                        "NetMsgSharedState state variables\n",
+                msgStream.m_stream.size() - msgStream.m_stream.tell());
+    }
 
     m_lockRequest = stream->read<uint8_t>();
 }

--- a/PlasMOUL/factory.cpp
+++ b/PlasMOUL/factory.cpp
@@ -64,10 +64,10 @@ MOUL::Creatable* MOUL::Factory::Create(uint16_t type)
     case id: return new cre(id);
 #include "creatable_types.inl"
 #undef CREATABLE_TYPE
-    case 0x8000: return static_cast<Creatable*>(0);
+    case 0x8000: return nullptr;
     default:
         fprintf(stderr, "[Factory] Tried to create unknown type %04X\n", type);
-        throw FactoryException(FactoryException::e_UnknownType);
+        throw FactoryException();
     }
 }
 

--- a/PlasMOUL/factory.h
+++ b/PlasMOUL/factory.h
@@ -57,24 +57,11 @@ namespace MOUL
         }
     };
 
-    class FactoryException : public std::exception
+    class FactoryException : public std::runtime_error
     {
     public:
-        enum Type { e_UnknownType };
-
-        FactoryException(Type type) throw() : m_type(type) { }
-        virtual ~FactoryException() throw() { }
-
-        virtual const char* what() const throw()
-        {
-            static const char* _messages[] = {
-                "[FactoryException] Unknown creatable ID"
-            };
-            return _messages[m_type];
-        }
-
-    private:
-        Type m_type;
+        FactoryException()
+            : std::runtime_error("[FactoryException] Unknown creatable ID") { }
     };
 }
 

--- a/SDL/StateInfo.cpp
+++ b/SDL/StateInfo.cpp
@@ -212,7 +212,7 @@ void SDL::Variable::_ref::read(DS::Stream* stream)
                 uint16_t type = stream->read<uint16_t>();
                 if (type != 0x8000) {
                     m_creatable[i] = MOUL::Factory::Create(type);
-                    DS_DASSERT(m_creatable[i] != 0);
+                    DS_ASSERT(m_creatable[i]);
                     const uint32_t endp = stream->tell() + stream->read<uint32_t>();
                     m_creatable[i]->read(stream);
                     if (stream->tell() != endp) {
@@ -265,10 +265,16 @@ void SDL::Variable::_ref::read(DS::Stream* stream)
             m_color8[i].m_A = stream->read<uint8_t>();
             break;
         case e_VarStateDesc:
-            DS_DASSERT(0);
+            // This should be handled elsewhere
+            DS_ASSERT(false);
+            break;
+        case e_VarAgeTimeOfDay:
+            // No data to read
             break;
         default:
-            break;
+            fprintf(stderr, "Invalid SDL variable type %d during read\n",
+                    static_cast<int>(m_desc->m_type));
+            throw DS::MalformedData();
         }
     }
 }
@@ -354,10 +360,16 @@ void SDL::Variable::_ref::write(DS::Stream* stream) const
             stream->write<uint8_t>(m_color8[i].m_A);
             break;
         case e_VarStateDesc:
-            DS_DASSERT(0);
+            // This should be handled elsewhere
+            DS_ASSERT(false);
+            break;
+        case e_VarAgeTimeOfDay:
+            // No data to write
             break;
         default:
-            break;
+            fprintf(stderr, "Invalid SDL variable type %d during write\n",
+                    static_cast<int>(m_desc->m_type));
+            throw DS::MalformedData();
         }
     }
 }
@@ -537,7 +549,7 @@ void SDL::Variable::copy(const SDL::Variable& rhs) {
 #ifdef DEBUG
 void SDL::Variable::debug()
 {
-    DS_DASSERT(m_data != 0);
+    DS_ASSERT(m_data);
 
     for (size_t i=0; i<m_data->m_size; ++i) {
         switch (m_data->m_desc->m_type) {
@@ -616,7 +628,7 @@ void SDL::Variable::debug()
 
 void SDL::Variable::setDefault()
 {
-    DS_DASSERT(m_data != 0);
+    DS_ASSERT(m_data);
 
     for (size_t i=0; i<m_data->m_size; ++i) {
         switch (m_data->m_desc->m_type) {
@@ -730,7 +742,7 @@ void SDL::Variable::setDefault()
 
 bool SDL::Variable::isDefault() const
 {
-    DS_DASSERT(m_data != 0);
+    DS_ASSERT(m_data);
 
     // Variable length vars are never at the default!
     // Why? The count is read/written in a !default block.

--- a/SDL/StateInfo.h
+++ b/SDL/StateInfo.h
@@ -204,10 +204,8 @@ namespace SDL
             DS::BlobStream bs(blob);
             State state = Create(&bs);
             state.read(&bs);
-#ifdef DEBUG
             if (!bs.atEof())
-                fprintf(stderr, "[SDL] Did not fully parse SDL blob! (@0x%x)\n", bs.tell());
-#endif
+                fprintf(stderr, "[SDL] WARNING: Did not fully parse SDL blob! (@0x%x)\n", bs.tell());
             return state;
         }
 

--- a/Types/ShaHash.cpp
+++ b/Types/ShaHash.cpp
@@ -77,10 +77,10 @@ DS::ShaHash DS::ShaHash::Sha0(const void* data, size_t size)
 {
     ShaHash result;
     const EVP_MD* sha0_md = EVP_get_digestbyname("sha");
-    DS_PASSERT(sha0_md);
+    DS_ASSERT(sha0_md);
 
     unsigned int out_len = EVP_MD_size(sha0_md);
-    DS_PASSERT(out_len == sizeof(result.m_data));
+    DS_ASSERT(out_len == sizeof(result.m_data));
 
     EVP_MD_CTX* sha_ctx = EVP_MD_CTX_create();
     EVP_DigestInit_ex(sha_ctx, sha0_md, NULL);
@@ -95,10 +95,10 @@ DS::ShaHash DS::ShaHash::Sha1(const void* data, size_t size)
 {
     ShaHash result;
     const EVP_MD* sha1_md = EVP_get_digestbyname("sha1");
-    DS_PASSERT(sha1_md);
+    DS_ASSERT(sha1_md);
 
     unsigned int out_len = EVP_MD_size(sha1_md);
-    DS_PASSERT(out_len == sizeof(result.m_data));
+    DS_ASSERT(out_len == sizeof(result.m_data));
 
     EVP_MD_CTX* sha1_ctx = EVP_MD_CTX_create();
     EVP_DigestInit_ex(sha1_ctx, sha1_md, NULL);

--- a/Types/Uuid.cpp
+++ b/Types/Uuid.cpp
@@ -23,9 +23,11 @@
 DS::Uuid::Uuid(const char* struuid)
 {
     char hexbuf[9];
-    DS_PASSERT(strlen(struuid) == 36);
-    DS_PASSERT(struuid[8] == '-' && struuid[13] == '-' && struuid[18] == '-'
-               && struuid[23] == '-');
+    if (strlen(struuid) != 36 || struuid[8] != '-' || struuid[13] != '-'
+            || struuid[18] != '-' || struuid[23] != '-') {
+        fprintf(stderr, "Invalid UUID string '%s'\n", struuid);
+        throw DS::MalformedData();
+    }
 
     /* First segment */
     memcpy(hexbuf, struuid, 8);

--- a/Types/Uuid.h
+++ b/Types/Uuid.h
@@ -25,8 +25,7 @@ namespace DS
     class Uuid
     {
     public:
-        Uuid() : m_data1(0), m_data2(0), m_data3(0)
-        { memset(m_data4, 0, sizeof(m_data4)); }
+        Uuid() { memset(m_bytes, 0, sizeof(m_bytes)); }
 
         Uuid(uint32_t data1, uint16_t data2, uint16_t data3, const uint8_t* data4)
             : m_data1(data1), m_data2(data2), m_data3(data3)

--- a/db/pqaccess.h
+++ b/db/pqaccess.h
@@ -117,3 +117,17 @@ namespace DS
                             params.m_values, nullptr, nullptr, 0);
     }
 }
+
+static inline void check_postgres(PGconn* postgres)
+{
+    auto status = PQstatus(postgres);
+    if (status == CONNECTION_BAD) {
+        PQreset(postgres);
+        status = PQstatus(postgres);
+    }
+    if (status != CONNECTION_OK) {
+        fprintf(stderr, "WARNING: Failed to reset postgres session.  Status = %d\n",
+                static_cast<int>(status));
+        fputs("The next postgres transaction is likely to fail...\n", stderr);
+    }
+}

--- a/errors.h
+++ b/errors.h
@@ -18,26 +18,21 @@
 #ifndef _DS_ERRORS_H
 #define _DS_ERRORS_H
 
-#include "errno.h"
+#include <cstdio>
+#include <cstdlib>
 #include <stdexcept>
 
 namespace DS
 {
-    class AssertException : public std::exception
+    __attribute__((noreturn))
+    inline void AssertionFailure(const char *condition, const char *file, long line)
+        noexcept
     {
-    public:
-        AssertException(const char* cond, const char* file, long line) throw()
-            : m_cond(cond), m_file(file), m_line(line) { }
-        virtual ~AssertException() throw() { }
-
-        virtual const char* what() const throw()
-        { return "[AssertException] Assertion Failed"; }
-
-    public:
-        const char* m_cond;
-        const char* m_file;
-        long m_line;
-    };
+        fprintf(stderr, "FATAL: Assertion Failure at %s:%ld: %s\n",
+                file, line, condition);
+        // Exit code 3 not used anywhere else...
+        exit(3);
+    }
 
     class MalformedData : public std::runtime_error
     {
@@ -54,13 +49,13 @@ namespace DS
     };
 }
 
-#define DS_PASSERT(cond) \
-    if (!(cond)) throw DS::AssertException(#cond, __FILE__, __LINE__)
+#define DS_ASSERT(cond) \
+    if (!(cond)) DS::AssertionFailure(#cond, __FILE__, __LINE__)
 
 #ifdef DEBUG
-#define DS_DASSERT(cond) DS_PASSERT(cond)
+#define DEBUG_printf(...)   printf(__VA_ARGS__)
 #else
-#define DS_DASSERT(cond)
+#define DEBUG_printf(...)   ((void)0)
 #endif
 
 #endif

--- a/errors.h
+++ b/errors.h
@@ -47,6 +47,15 @@ namespace DS
         InvalidConnectionHeader()
             : std::runtime_error("Invalid connection header received from client") { }
     };
+
+    // A "catchable" system error
+    class SystemError : public std::runtime_error
+    {
+    public:
+        SystemError(const char *message, const char *error)
+            : std::runtime_error(std::string(message) + ": " + std::string(error))
+        { }
+    };
 }
 
 #define DS_ASSERT(cond) \

--- a/errors.h
+++ b/errors.h
@@ -45,6 +45,13 @@ namespace DS
         MalformedData()
             : std::runtime_error("Malformed stream data from client") { }
     };
+
+    class InvalidConnectionHeader : public std::runtime_error
+    {
+    public:
+        InvalidConnectionHeader()
+            : std::runtime_error("Invalid connection header received from client") { }
+    };
 }
 
 #define DS_PASSERT(cond) \

--- a/errors.h
+++ b/errors.h
@@ -19,7 +19,7 @@
 #define _DS_ERRORS_H
 
 #include "errno.h"
-#include <exception>
+#include <stdexcept>
 
 namespace DS
 {
@@ -37,6 +37,13 @@ namespace DS
         const char* m_cond;
         const char* m_file;
         long m_line;
+    };
+
+    class MalformedData : public std::runtime_error
+    {
+    public:
+        MalformedData()
+            : std::runtime_error("Malformed stream data from client") { }
     };
 }
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -235,7 +235,7 @@ void DS::Settings::UseDefaults()
 
 const uint8_t* DS::Settings::CryptKey(DS::KeyType key)
 {
-    DS_DASSERT(static_cast<int>(key) >= 0 && static_cast<int>(key) < e_KeyMaxTypes);
+    DS_ASSERT(static_cast<int>(key) >= 0 && static_cast<int>(key) < e_KeyMaxTypes);
     return s_settings.m_cryptKeys[key];
 }
 

--- a/streams.cpp
+++ b/streams.cpp
@@ -233,7 +233,8 @@ void DS::BlobStream::seek(int32_t offset, int whence)
 DS::Blob DS::Base64Decode(const ST::string& value)
 {
     ST_ssize_t resultLen = ST::base64_decode(value, nullptr, 0);
-    DS_PASSERT(resultLen >= 0);
+    if (resultLen < 0)
+        throw DS::MalformedData();
 
     uint8_t* result = new uint8_t[resultLen];
     ST::base64_decode(value, result, resultLen);
@@ -243,7 +244,8 @@ DS::Blob DS::Base64Decode(const ST::string& value)
 DS::Blob DS::HexDecode(const ST::string& value)
 {
     ST_ssize_t resultLen = ST::hex_decode(value, nullptr, 0);
-    DS_PASSERT(resultLen >= 0);
+    if (resultLen < 0)
+        throw DS::MalformedData();
 
     uint8_t* result = new uint8_t[resultLen];
     ST::hex_decode(value, result, resultLen);

--- a/streams.h
+++ b/streams.h
@@ -20,34 +20,24 @@
 
 #include <string_theory/string>
 #include <atomic>
-#include <exception>
+#include <stdexcept>
 #include <cstdio>
 #include <cstring>
 
 namespace DS
 {
-    class EofException : public std::exception
+    class EofException : public std::runtime_error
     {
     public:
-        EofException() throw() { }
-        virtual ~EofException() throw() { }
-
-        virtual const char* what() const throw()
-        { return "[EofException] Unexpected end of stream"; }
+        EofException()
+            : std::runtime_error("[EofException] Unexpected end of stream") { }
     };
 
-    class FileIOException : public std::exception
+    class FileIOException : public std::runtime_error
     {
     public:
-        FileIOException(const char* msg) throw()
-            : m_errmsg(ST_LITERAL("[FileIOException] ") + msg) { }
-        virtual ~FileIOException() throw() { }
-
-        virtual const char* what() const throw()
-        { return m_errmsg.c_str(); }
-
-    private:
-        ST::string m_errmsg;
+        explicit FileIOException(const char* msg)
+            : std::runtime_error(std::string("[FileIOException] ") + msg) { }
     };
 
     enum StringType


### PR DESCRIPTION
Stop the abuse of assert macros!  This change reserves DS_ASSERT only for fatal programming or environment errors that can't be recovered from.  Many of the cases it was being (ab)used for are now reworked into more meaningful exceptions, warnings, or even descriptive fatal errors, and many cases where asserts were used (or worse ignored due to Release builds) to escape from a trivial data parsing issue are now handled more gracefully instead of just dropping a client (or in some cases, a server process).

Obviously this is a non-trivial refactor, so it should be reviewed and tested carefully, but I think it will generally improve the quality of dirtsand's error handling.