### PR TITLE
Fix incorrect error check in `dm_auth_createPlayer`

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -59,7 +59,7 @@ void dm_auth_addacct(Auth_AddAcct* msg)
                 "    VALUES ($1, $2, $3, 0, 1)",
                 gen_uuid().toString(), pwHash.toString(),
                 msg->m_acctInfo.m_acctName);
-        if (PQresultStatus(result) != PGRES_TUPLES_OK) {
+        if (PQresultStatus(result) != PGRES_COMMAND_OK) {
             fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                     __FILE__, __LINE__, PQerrorMessage(s_postgres));
             SEND_REPLY(msg, DS::e_NetInternalError);

--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -419,7 +419,7 @@ void dm_auth_createPlayer(Auth_PlayerCreate* msg)
             client->m_acctUuid.toString(), msg->m_player.m_playerId,
             msg->m_player.m_playerName, msg->m_player.m_avatarModel,
             msg->m_player.m_explorer);
-    if (PQresultStatus(result) != PGRES_TUPLES_OK) {
+    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
         fprintf(stderr, "%s:%d:\n    Postgres INSERT error: %s\n",
                 __FILE__, __LINE__, PQerrorMessage(s_postgres));
         SEND_REPLY(msg, DS::e_NetInternalError);


### PR DESCRIPTION
This incorrect error check caused a false failure on player creation.