### PR TITLE
Add hand-rolled SHA-0 implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Debug
       -DCMAKE_PREFIX_PATH="${TRAVIS_BUILD_DIR}/build_deps/prefix" ..
   - make -j2
+  - ./test_sha

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,3 +161,15 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/bin/dsData.sh
         DESTINATION "bin")
 install(FILES static_ages.ini
         DESTINATION ".")
+
+# TODO: Build proper unit test framework...
+option(ENABLE_TESTS "Enable building and running unit tests" ON)
+
+if(ENABLE_TESTS)
+    add_executable(test_sha Types/ShaHash.cpp Types/ShaHash.h)
+    target_compile_definitions(test_sha PRIVATE DS_BUILD_SHA0_TESTS)
+    # Dependencies needed for ShaHash
+    target_sources(test_sha PRIVATE streams.cpp streams.h errors.h)
+    target_link_libraries(test_sha PRIVATE ${OPENSSL_CRYPTO_LIBRARIES}
+                                           ${STRING_THEORY_LIBRARIES})
+endif()

--- a/Types/ShaHash.cpp
+++ b/Types/ShaHash.cpp
@@ -20,12 +20,13 @@
 #include <string_theory/format>
 #include <openssl/evp.h>
 #include <cstdlib>
+#include <memory>
 
 /* Cyan makes their SHA hashes 5 LE dwords instead of 20 bytes, making our
  * lives more difficult and annoying.
  */
-#define SWAP_BYTES(x) (((x) & 0xFF000000) >> 24) | (((x) & 0x00FF0000) >> 8) \
-                   |  (((x) & 0x000000FF) << 24) | (((x) & 0x0000FF00) << 8)
+#define SWAP_BYTES(x) __builtin_bswap32((x))
+#define SWAP_BYTES64(x) __builtin_bswap64((x))
 
 DS::ShaHash::ShaHash(const char* struuid)
 {
@@ -73,12 +74,17 @@ ST::string DS::ShaHash::toString() const
                       SWAP_BYTES(m_data[4]));
 }
 
+static DS::ShaHash _ds_internal_sha0(const void *data, size_t size);
+
 DS::ShaHash DS::ShaHash::Sha0(const void* data, size_t size)
 {
-    ShaHash result;
     const EVP_MD* sha0_md = EVP_get_digestbyname("sha");
-    DS_ASSERT(sha0_md);
+    if (!sha0_md) {
+        // Use our own implementation only if OpenSSL doesn't support it
+        return _ds_internal_sha0(data, size);
+    }
 
+    ShaHash result;
     unsigned int out_len = EVP_MD_size(sha0_md);
     DS_ASSERT(out_len == sizeof(result.m_data));
 
@@ -108,3 +114,140 @@ DS::ShaHash DS::ShaHash::Sha1(const void* data, size_t size)
 
     return result;
 }
+
+constexpr uint32_t rol32(uint32_t value, unsigned int n)
+{
+    // GCC and Clang will optimize this to a single rol instruction on x86
+    return (value << n) | (value >> (32 - n));
+}
+
+static DS::ShaHash _ds_internal_sha0(const void* data, size_t size)
+{
+    static const uint32_t K[] = {
+        0x5a827999,
+        0x6ed9eba1,
+        0x8f1bbcdc,
+        0xca62c1d6
+    };
+
+    static const std::function<uint32_t (uint32_t*)> F[] = {
+        [](uint32_t* hv) { return (hv[1] & hv[2]) | (~hv[1] & hv[3]); },
+        [](uint32_t* hv) { return (hv[1] ^ hv[2] ^ hv[3]); },
+        [](uint32_t* hv) { return (hv[1] & hv[2]) | (hv[1] & hv[3]) | (hv[2] & hv[3]); },
+        [](uint32_t* hv) { return (hv[1] ^ hv[2] ^ hv[3]); }
+    };
+
+    uint32_t hash[5] = {
+        0x67452301,
+        0xefcdab89,
+        0x98badcfe,
+        0x10325476,
+        0xc3d2e1f0
+    };
+
+    uint8_t stack_buffer[256];
+    std::unique_ptr<uint8_t[]> heap_buffer;
+    uint8_t *bufp;
+
+    // Preprocess the message to pad it to a multiple of 512 bits,
+    // with the (Big Endian) size in bits tacked onto the end.
+    uint64_t buf_size = size + 1 + sizeof(uint64_t);
+    if ((buf_size % 64) != 0)
+        buf_size += 64 - (buf_size % 64);
+    if (buf_size > sizeof(stack_buffer)) {
+        heap_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[buf_size]);
+        bufp = heap_buffer.get();
+    } else {
+        bufp = stack_buffer;
+    }
+
+    memcpy(bufp, data, size);
+    memset(bufp + size, 0, buf_size - size);
+    bufp[size] = 0x80;  // Append '1' bit to the end of the message
+    uint64_t msg_size_bits = SWAP_BYTES64(static_cast<uint64_t>(size) * 8);
+    memcpy(bufp + buf_size - sizeof(msg_size_bits),
+           &msg_size_bits, sizeof(msg_size_bits));
+
+    uint8_t* end = bufp + buf_size;
+    uint32_t work[80];
+    while (bufp < end) {
+        memcpy(work, bufp, 64);
+        bufp += 64;
+
+        for (size_t i = 0; i < 16; ++i)
+            work[i] = SWAP_BYTES(work[i]);
+
+        for (size_t i = 16; i < 80; ++i) {
+            // SHA-1 difference: no rol32(work[i], 1)
+            work[i] = work[i-3] ^ work[i-8] ^ work[i-14] ^ work[i-16];
+        }
+
+        uint32_t hv[5];
+        memcpy(hv, hash, sizeof(hv));
+
+        // Main SHA loop
+        for (size_t i = 0; i < 80; ++i) {
+            const size_t stage = i / 20;
+            const uint32_t f = F[stage](hv);
+            const uint32_t temp = rol32(hv[0], 5) + f + hv[4] + K[stage] + work[i];
+            hv[4] = hv[3];
+            hv[3] = hv[2];
+            hv[2] = rol32(hv[1], 30);
+            hv[1] = hv[0];
+            hv[0] = temp;
+        }
+
+        hash[0] += hv[0];
+        hash[1] += hv[1];
+        hash[2] += hv[2];
+        hash[3] += hv[3];
+        hash[4] += hv[4];
+    }
+
+    // Bring the output back to host endian
+    for (size_t i = 0; i < 5; ++i)
+        hash[i] = SWAP_BYTES(hash[i]);
+
+    return DS::ShaHash(reinterpret_cast<const uint8_t*>(hash));
+}
+
+#ifdef DS_BUILD_SHA0_TESTS
+#define EXPECT_SHA(sha, expr)                                           \
+{                                                                       \
+    const DS::ShaHash hash = (expr);                                    \
+    if (hash.toString() != sha) {                                       \
+        fprintf(stderr, "Incorrect SHA hash for " #expr ":\n");         \
+        fprintf(stderr, "  Expected: " sha "\n");                       \
+        fprintf(stderr, "  Actual:   %s\n", hash.toString().c_str());   \
+        ++test_fails;                                                   \
+    }                                                                   \
+}
+
+int main()
+{
+    int test_fails = 0;
+
+    // Sanity check EXPECT_SHA with known-good SHA-1 implementation
+    EXPECT_SHA("da39a3ee5e6b4b0d3255bfef95601890afd80709",
+               DS::ShaHash::Sha1("", 0));
+    EXPECT_SHA("a9993e364706816aba3e25717850c26c9cd0d89d",
+               DS::ShaHash::Sha1("abc", 3));
+
+    // Now the SHA-0 tests
+    EXPECT_SHA("f96cea198ad1dd5617ac084a3d92c6107708c0ef",
+               DS::ShaHash::Sha0("", 0));
+    EXPECT_SHA("37f297772fae4cb1ba39b6cf9cf0381180bd62f2",
+               DS::ShaHash::Sha0("a", 1));
+    EXPECT_SHA("0164b8a914cd2a5e74c4f7ff082c4d97f1edf880",
+               DS::ShaHash::Sha0("abc", 3));
+    EXPECT_SHA("d2516ee1acfa5baf33dfc1c471e438449ef134c8",
+               DS::ShaHash::Sha0("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", 56));
+    EXPECT_SHA("459f83b95db2dc87bb0f5b513a28f900ede83237",
+               DS::ShaHash::Sha0("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                                 "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu", 112));
+
+    if (test_fails == 0)
+        printf("All tests passed!\n");
+    return test_fails;
+}
+#endif

--- a/Types/ShaHash.cpp
+++ b/Types/ShaHash.cpp
@@ -243,6 +243,8 @@ int main()
 {
     int test_fails = 0;
 
+    OpenSSL_add_all_digests();
+
     // Sanity check EXPECT_SHA with known-good SHA-1 implementation
     EXPECT_SHA("da39a3ee5e6b4b0d3255bfef95601890afd80709",
                DS::ShaHash::Sha1("", 0));


### PR DESCRIPTION
Add hand-rolled SHA-0 implementation to work around its removal in OpenSSL 1.1 without asserting.