### PR TITLE
Improve dirtsand startup

### DIFF
--- a/NetIO/Lobby.cpp
+++ b/NetIO/Lobby.cpp
@@ -111,9 +111,14 @@ void dm_lobby()
 
 void DS::StartLobby()
 {
-    s_listenSock = DS::BindSocket(DS::Settings::LobbyAddress(),
-                                  DS::Settings::LobbyPort());
-    DS::ListenSock(s_listenSock);
+    try {
+        s_listenSock = DS::BindSocket(DS::Settings::LobbyAddress(),
+                                      DS::Settings::LobbyPort());
+        DS::ListenSock(s_listenSock);
+    } catch (const SystemError &err) {
+        fputs(err.what(), stderr);
+        exit(1);
+    }
     s_lobbyThread = std::thread(&dm_lobby);
 }
 

--- a/NetIO/Status.cpp
+++ b/NetIO/Status.cpp
@@ -173,14 +173,22 @@ void dm_htserv()
 
 void DS::StartStatusHTTP()
 {
-    s_listenSock = DS::BindSocket(DS::Settings::StatusAddress(),
-                                  DS::Settings::StatusPort());
-    DS::ListenSock(s_listenSock);
+    try {
+        s_listenSock = DS::BindSocket(DS::Settings::StatusAddress(),
+                                      DS::Settings::StatusPort());
+        DS::ListenSock(s_listenSock);
+    } catch (const SystemError &err) {
+        fprintf(stderr, "[Status] WARNING: Could not start the HTTP server: %s\n",
+                err.what());
+        return;
+    }
     s_httpThread = std::thread(&dm_htserv);
 }
 
 void DS::StopStatusHTTP()
 {
-    DS::CloseSock(s_listenSock);
-    s_httpThread.join();
+    if (s_httpThread.joinable()) {
+        DS::CloseSock(s_listenSock);
+        s_httpThread.join();
+    }
 }

--- a/errors.h
+++ b/errors.h
@@ -52,6 +52,10 @@ namespace DS
     class SystemError : public std::runtime_error
     {
     public:
+        explicit SystemError(const char *message)
+            : std::runtime_error(std::string(message))
+        { }
+
         SystemError(const char *message, const char *error)
             : std::runtime_error(std::string(message) + ": " + std::string(error))
         { }

--- a/settings.cpp
+++ b/settings.cpp
@@ -18,6 +18,8 @@
 #include "settings.h"
 #include "errors.h"
 #include "streams.h"
+
+#include <string_theory/stdio>
 #include <vector>
 #include <cstdio>
 
@@ -91,9 +93,9 @@ static struct
     { \
         Blob data = Base64Decode(params[1]); \
         if (data.size() != fixedsize) { \
-            fprintf(stderr, "Invalid base64 blob size for %s: " \
-                            "Expected %u bytes, got %zu bytes\n", \
-                    params[0].c_str(), fixedsize, data.size()); \
+            ST::printf(stderr, "Invalid base64 blob size for {}: " \
+                               "Expected {} bytes, got {} bytes\n", \
+                       params[0], fixedsize, data.size()); \
             return false; \
         } \
         memcpy(outbuffer, data.buffer(), fixedsize); \
@@ -102,7 +104,7 @@ static struct
 #define BUF_TO_UINT(bufptr) \
     ((bufptr)[0] << 24) | ((bufptr)[1] << 16) | ((bufptr)[2] << 8) | (bufptr)[3]
 
-bool DS::Settings::LoadFrom(const char* filename)
+bool DS::Settings::LoadFrom(const ST::string& filename)
 {
     UseDefaults();
 
@@ -113,9 +115,9 @@ bool DS::Settings::LoadFrom(const char* filename)
     else
         s_settings.m_settingsPath = ".";
 
-    FILE* cfgfile = fopen(filename, "r");
+    FILE* cfgfile = fopen(filename.c_str(), "r");
     if (!cfgfile) {
-        fprintf(stderr, "Cannot open %s for reading\n", filename);
+        ST::printf(stderr, "Cannot open {} for reading\n", filename);
         return false;
     }
 
@@ -127,7 +129,7 @@ bool DS::Settings::LoadFrom(const char* filename)
                 continue;
             std::vector<ST::string> params = line.split('=', 1);
             if (params.size() != 2) {
-                fprintf(stderr, "Warning: Invalid config line: %s\n", line.c_str());
+                ST::printf(stderr, "Warning: Invalid config line: {}\n", line);
                 continue;
             }
 
@@ -200,8 +202,7 @@ bool DS::Settings::LoadFrom(const char* filename)
             } else if (params[0] == "Welcome.Msg") {
                 s_settings.m_welcome = params[1];
             } else {
-                fprintf(stderr, "Warning: Unknown setting '%s' ignored\n",
-                        params[0].c_str());
+                ST::printf(stderr, "Warning: Unknown setting '{}' ignored\n", params[0]);
             }
         }
     }

--- a/settings.cpp
+++ b/settings.cpp
@@ -262,7 +262,9 @@ ST::string DS::Settings::GameServerAddress()
 
 const char* DS::Settings::LobbyAddress()
 {
-    return s_settings.m_lobbyAddr.is_empty() ? 0 : s_settings.m_lobbyAddr.c_str();
+    return s_settings.m_lobbyAddr.is_empty()
+                ? "127.0.0.1"   /* Not useful for external connections */
+                : s_settings.m_lobbyAddr.c_str();
 }
 
 const char* DS::Settings::LobbyPort()
@@ -277,7 +279,9 @@ bool DS::Settings::StatusEnabled()
 
 const char* DS::Settings::StatusAddress()
 {
-    return s_settings.m_statusAddr.is_empty() ? 0 : s_settings.m_statusAddr.c_str();
+    return s_settings.m_statusAddr.is_empty()
+                ? "127.0.0.1"   /* Not useful for external connections */
+                : s_settings.m_statusAddr.c_str();
 }
 
 const char* DS::Settings::StatusPort()

--- a/settings.h
+++ b/settings.h
@@ -80,7 +80,7 @@ namespace DS
         ST::string WelcomeMsg();
         void SetWelcomeMsg(const ST::string& welcome);
 
-        bool LoadFrom(const char* filename);
+        bool LoadFrom(const ST::string& filename);
         void UseDefaults();
     }
 }


### PR DESCRIPTION
- Automatically detect dirtsand.ini if it's in a "usual" location.
- Don't crash if something else is listening on port 8080 -- just display a warning and move on.
- General cleanup.