### PR TITLE
Require string_theory 2.0.

### DIFF
--- a/AuthServ/AuthDaemon.cpp
+++ b/AuthServ/AuthDaemon.cpp
@@ -986,7 +986,7 @@ void dm_auth_update_globalSDL(Auth_UpdateGlobalSDL* msg)
             var->data()->m_flags |= SDL::Variable::e_HasTimeStamp | SDL::Variable::e_XIsDirty;
             var->data()->m_timestamp.setNow();
 
-            if (msg->m_value.is_empty()) {
+            if (msg->m_value.empty()) {
                 var->setDefault();
             } else {
                 var->data()->m_flags &= ~SDL::Variable::e_SameAsDefault;

--- a/AuthServ/AuthManifest.cpp
+++ b/AuthServ/AuthManifest.cpp
@@ -37,7 +37,7 @@ DS::NetResultCode DS::AuthManifest::loadManifest(const char* filename)
     while (fgets(lnbuf, 4096, mfs)) {
         ++mfsline;
         ST::string line = ST::string(lnbuf).before_first('#').trim();
-        if (line.is_empty())
+        if (line.empty())
             continue;
 
         std::vector<ST::string> parts = line.split(',');

--- a/AuthServ/AuthVault.cpp
+++ b/AuthServ/AuthVault.cpp
@@ -148,10 +148,10 @@ std::list<AuthServer_AgeInfo> configure_static_ages()
         bool haveAge = false;
         while (fgets(buffer, 4096, cfgfile)) {
             ST::string line = ST::string(buffer).before_first('#').trim();
-            if (line.is_empty())
+            if (line.empty())
                 continue;
 
-            if (line.trim().char_at(0) == '[') {
+            if (line.trim().front() == '[') {
                 if (haveAge)
                     configs.push_back(age);
                 age.clear();
@@ -466,11 +466,11 @@ v_create_age(AuthServer_AgeInfo age, uint32_t flags)
     if (!age.m_parentId.isNull())
         node.set_Uuid_2(age.m_parentId);
     node.set_String64_2(age.m_filename);
-    if (!age.m_instName.is_empty())
+    if (!age.m_instName.empty())
         node.set_String64_3(age.m_instName);
-    if (!age.m_userName.is_empty())
+    if (!age.m_userName.empty())
         node.set_String64_4(age.m_userName);
-    if (!age.m_description.is_empty())
+    if (!age.m_description.empty())
         node.set_Text_1(age.m_description);
     uint32_t ageInfoNode = v_create_node(node);
     if (ageInfoNode == 0)
@@ -546,8 +546,8 @@ v_create_age(AuthServer_AgeInfo age, uint32_t flags)
 
     // Register with the server database
     {
-        ST::string agedesc = !age.m_description.is_empty() ? age.m_description
-                           : !age.m_instName.is_empty() ? age.m_instName
+        ST::string agedesc = !age.m_description.empty() ? age.m_description
+                           : !age.m_instName.empty() ? age.m_instName
                            : age.m_filename;
 
         DS::PGresultRef result = DS::PQexecVA(s_postgres,

--- a/AuthServ/VaultTypes.cpp
+++ b/AuthServ/VaultTypes.cpp
@@ -23,11 +23,10 @@
         uint32_t length = stream->read<uint32_t>(); \
         if ((length % sizeof(char16_t)) != 0) \
             throw DS::MalformedData(); \
-        ST::utf16_buffer storage; \
-        char16_t* buffer = storage.create_writable_buffer(length / sizeof(char16_t)); \
-        stream->readBytes(buffer, length); \
-        value = ST::string::from_utf16(buffer, (length / sizeof(char16_t))-1, \
-                                       ST::substitute_invalid); \
+        ST::utf16_buffer buffer; \
+        buffer.allocate(length / sizeof(char16_t)); \
+        stream->readBytes(buffer.data(), length); \
+        value = ST::string::from_utf16(buffer, ST::substitute_invalid); \
     }
 
 #define WRITE_VAULT_STRING(value) \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(dirtsand)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set up Product Identification parameters (NOTE: Should match plClient)
@@ -40,7 +40,7 @@ find_package(PostgreSQL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Readline REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(string_theory 1.7 REQUIRED)
+find_package(string_theory 2.0 REQUIRED)
 find_package(Threads REQUIRED)
 
 set(PlasMOUL_SOURCES
@@ -136,7 +136,7 @@ set_target_properties(dirtsand PROPERTIES
 
 target_compile_definitions(dirtsand PRIVATE
     $<$<CONFIG:Debug>:DEBUG>
-    ST_NO_2_0_DEPRECATION
+    ST_NO_3_0_DEPRECATION
     PRODUCT_BRANCH_ID=${PRODUCT_BRANCH_ID}
     PRODUCT_BUILD_ID=${PRODUCT_BUILD_ID}
     PRODUCT_BUILD_TYPE=${PRODUCT_BUILD_TYPE}
@@ -180,7 +180,7 @@ if(ENABLE_TESTS)
     target_compile_definitions(test_sha PRIVATE DS_BUILD_SHA0_TESTS)
     # Dependencies needed for ShaHash
     target_sources(test_sha PRIVATE streams.cpp streams.h errors.h)
-    target_compile_definitions(test_sha PRIVATE ST_NO_2_0_DEPRECATION)
+    target_compile_definitions(test_sha PRIVATE ST_NO_3_0_DEPRECATION)
     target_include_directories(test_sha PRIVATE "${CMAKE_SOURCE_DIR}")
     target_link_libraries(test_sha PRIVATE ${OPENSSL_CRYPTO_LIBRARIES}
                                            ${STRING_THEORY_LIBRARIES})

--- a/FileServ/FileManifest.cpp
+++ b/FileServ/FileManifest.cpp
@@ -38,7 +38,7 @@ DS::NetResultCode DS::FileManifest::loadManifest(const char* filename)
     while (fgets(lnbuf, 4096, mfs)) {
         ++mfsline;
         ST::string line = ST::string(lnbuf).before_first('#').trim();
-        if (line.is_empty())
+        if (line.empty())
             continue;
 
         std::vector<ST::string> parts = line.split(',');

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -326,7 +326,7 @@ Game_AgeInfo age_parse(FILE* stream)
     Game_AgeInfo age;
     while (fgets(lnbuffer, 4096, stream)) {
         ST::string trimmed = ST::string(lnbuffer).before_first('#').trim();
-        if (trimmed.is_empty())
+        if (trimmed.empty())
             continue;
         std::vector<ST::string> line = trimmed.split('=');
         if (line.size() != 2) {

--- a/NetIO/Status.cpp
+++ b/NetIO/Status.cpp
@@ -79,7 +79,7 @@ void dm_htserv()
                 if (cp != sp)
                     scratch += sp;
 
-                if (lines.size() && lines.back().is_empty()) {
+                if (lines.size() && lines.back().empty()) {
                     // Got the separator line
                     break;
                 }

--- a/PlasMOUL/AgeLinkStruct.h
+++ b/PlasMOUL/AgeLinkStruct.h
@@ -46,21 +46,21 @@ namespace MOUL
         void setTitle(const ST::string& title)
         {
             m_title = title;
-            m_flags.set(e_HasTitle, !title.is_empty());
+            m_flags.set(e_HasTitle, !title.empty());
         }
 
         ST::string name() const { return m_spawnPt; }
         void setName(const ST::string& name)
         {
             m_spawnPt = name;
-            m_flags.set(e_HasName, !name.is_empty());
+            m_flags.set(e_HasName, !name.empty());
         }
 
         ST::string cameraStack() const { return m_cameraStack; }
         void setCameraStack(const ST::string& stack)
         {
             m_cameraStack = stack;
-            m_flags.set(e_HasCameraStack, !stack.is_empty());
+            m_flags.set(e_HasCameraStack, !stack.empty());
         }
 
     protected:
@@ -80,14 +80,14 @@ namespace MOUL
         void setFilename(const ST::string& filename)
         {
             m_ageFilename = filename;
-            UPDATEFLAG(e_HasAgeFilename, !filename.is_empty());
+            UPDATEFLAG(e_HasAgeFilename, !filename.empty());
         }
 
         ST::string instanceName() const { return m_ageInstanceName; }
         void setInstanceName(const ST::string& name)
         {
             m_ageInstanceName = name;
-            UPDATEFLAG(e_HasAgeInstanceName, !name.is_empty());
+            UPDATEFLAG(e_HasAgeInstanceName, !name.empty());
         }
 
         DS::Uuid instanceUuid() const { return m_ageInstanceUuid; }
@@ -101,7 +101,7 @@ namespace MOUL
         void setUserDefinedName(const ST::string& name)
         {
             m_ageUserDefinedName = name;
-            UPDATEFLAG(e_HasAgeUserDefinedName, !name.is_empty());
+            UPDATEFLAG(e_HasAgeUserDefinedName, !name.empty());
         }
 
         int32_t sequenceNumber() const { return m_ageSequenceNumber; }
@@ -115,7 +115,7 @@ namespace MOUL
         void setDescription(const ST::string& description)
         {
             m_ageDescription = description;
-            UPDATEFLAG(e_HasAgeDescription, !description.is_empty());
+            UPDATEFLAG(e_HasAgeDescription, !description.empty());
         }
 
         int32_t language() const { return m_ageLanguage; }
@@ -179,7 +179,7 @@ namespace MOUL
         void setParentAgeFilename(const ST::string& filename)
         {
             m_parentAgeFilename = filename;
-            UPDATEFLAG(e_HasParentAgeFilename, !filename.is_empty());
+            UPDATEFLAG(e_HasParentAgeFilename, !filename.empty());
         }
 
     protected:

--- a/SDL/StateInfo.cpp
+++ b/SDL/StateInfo.cpp
@@ -424,7 +424,7 @@ void SDL::Variable::read(DS::Stream* stream)
 void SDL::Variable::write(DS::Stream* stream) const
 {
     uint8_t contents = 0;
-    if (!m_data->m_notificationHint.is_empty())
+    if (!m_data->m_notificationHint.empty())
         contents |= e_HasNotificationInfo;
     stream->write<uint8_t>(contents);
     if (contents & e_HasNotificationInfo) {

--- a/settings.cpp
+++ b/settings.cpp
@@ -125,7 +125,7 @@ bool DS::Settings::LoadFrom(const ST::string& filename)
         char buffer[4096];
         while (fgets(buffer, 4096, cfgfile)) {
             ST::string line = ST::string(buffer).before_first('#').trim();
-            if (line.is_empty())
+            if (line.empty())
                 continue;
             std::vector<ST::string> params = line.split('=', 1);
             if (params.size() != 2) {
@@ -262,7 +262,7 @@ ST::string DS::Settings::GameServerAddress()
 
 const char* DS::Settings::LobbyAddress()
 {
-    return s_settings.m_lobbyAddr.is_empty()
+    return s_settings.m_lobbyAddr.empty()
                 ? "127.0.0.1"   /* Not useful for external connections */
                 : s_settings.m_lobbyAddr.c_str();
 }
@@ -279,7 +279,7 @@ bool DS::Settings::StatusEnabled()
 
 const char* DS::Settings::StatusAddress()
 {
-    return s_settings.m_statusAddr.is_empty()
+    return s_settings.m_statusAddr.empty()
                 ? "127.0.0.1"   /* Not useful for external connections */
                 : s_settings.m_statusAddr.c_str();
 }

--- a/streams.cpp
+++ b/streams.cpp
@@ -26,19 +26,17 @@ ST::string DS::Stream::readString(size_t length, DS::StringType format)
 {
     if (format == e_StringUTF16) {
         ST::utf16_buffer result;
-        char16_t* buffer = result.create_writable_buffer(length);
-        ssize_t bytes = readBytes(buffer, length * sizeof(char16_t));
+        result.allocate(length);
+        ssize_t bytes = readBytes(result.data(), length * sizeof(char16_t));
         if (bytes != static_cast<ssize_t>(length * sizeof(char16_t)))
             throw EofException();
-        buffer[length] = 0;
         return ST::string::from_utf16(result, ST::substitute_invalid);
     } else {
         ST::char_buffer result;
-        char* buffer = result.create_writable_buffer(length);
-        ssize_t bytes = readBytes(buffer, length * sizeof(char));
+        result.allocate(length);
+        ssize_t bytes = readBytes(result.data(), length * sizeof(char));
         if (bytes != static_cast<ssize_t>(length * sizeof(char)))
             throw EofException();
-        buffer[length] = 0;
         return (format == e_StringUTF8) ? ST::string::from_utf8(result, ST::substitute_invalid)
                                         : ST::string::from_latin_1(result);
     }
@@ -53,28 +51,26 @@ ST::string DS::Stream::readSafeString(DS::StringType format)
 
     if (format == e_StringUTF16) {
         ST::utf16_buffer result;
-        char16_t* buffer = result.create_writable_buffer(length);
-        ssize_t bytes = readBytes(buffer, length * sizeof(char16_t));
+        result.allocate(length);
+        ssize_t bytes = readBytes(result.data(), length * sizeof(char16_t));
         read<char16_t>(); // redundant u'\0'
         if (bytes != static_cast<ssize_t>(length * sizeof(char16_t)))
             throw EofException();
-        if (length && (buffer[0] & 0x8000)) {
+        if ((result.front() & 0x8000) != 0) {
             for (uint16_t i=0; i<length; ++i)
-                buffer[i] = ~buffer[i];
+                result[i] = ~result[i];
         }
-        buffer[length] = 0;
         return ST::string::from_utf16(result, ST::substitute_invalid);
     } else {
         ST::char_buffer result;
-        char* buffer = result.create_writable_buffer(length);
-        ssize_t bytes = readBytes(buffer, length * sizeof(char));
+        result.allocate(length);
+        ssize_t bytes = readBytes(result.data(), length * sizeof(char));
         if (bytes != static_cast<ssize_t>(length * sizeof(char)))
             throw EofException();
-        if (length && (buffer[0] & 0x80)) {
+        if ((result.front() & 0x80) != 0) {
             for (uint16_t i=0; i<length; ++i)
-                buffer[i] = ~buffer[i];
+                result[i] = ~result[i];
         }
-        buffer[length] = 0;
         return (format == e_StringUTF8)
                ? ST::string::from_utf8(result, ST::substitute_invalid)
                : ST::string::from_latin_1(result);
@@ -98,25 +94,19 @@ void DS::Stream::writeSafeString(const ST::string& value, DS::StringType format)
     if (format == e_StringUTF16) {
         ST::utf16_buffer buffer = value.to_utf16();
         uint16_t length = value.size() & 0x0FFF;
-        ST::utf16_buffer work;
-        char16_t* data = work.create_writable_buffer(length);
-        memcpy(data, buffer.data(), length * sizeof(char16_t));
         for (uint16_t i=0; i<length; ++i)
-            data[i] = ~data[i];
+            buffer[i] = ~buffer[i];
         write<uint16_t>(length | 0xF000);
-        writeBytes(data, length * sizeof(char16_t));
+        writeBytes(buffer.data(), length * sizeof(char16_t));
         write<char16_t>(0);
     } else {
         ST::char_buffer buffer = (format == e_StringUTF8) ? value.to_utf8()
                                : value.to_latin_1(ST::substitute_invalid);
         uint16_t length = value.size() & 0x0FFF;
-        ST::char_buffer work;
-        char* data = work.create_writable_buffer(length);
-        memcpy(data, buffer.data(), length * sizeof(char));
         for (uint16_t i=0; i<length; ++i)
-            data[i] = ~data[i];
+            buffer[i] = ~buffer[i];
         write<uint16_t>(length | 0xF000);
-        writeBytes(data, length * sizeof(char));
+        writeBytes(buffer.data(), length * sizeof(char));
     }
 }
 


### PR DESCRIPTION
* Fixes compatibility with string_theory master (to be 3.0)
* Removes an unnecessary extra allocation/copy in SafeString writes.