### PR TITLE
Fix segfault on GameHost start.

### DIFF
--- a/AuthServ/AuthVault.cpp
+++ b/AuthServ/AuthVault.cpp
@@ -26,7 +26,7 @@
 
 static uint32_t s_systemNode = 0;
 extern PGconn* s_postgres;
-extern std::unordered_map<ST::string, SDL::State, ST::hash> s_globalStates;
+extern std::unordered_map<ST::string, SDL::State, ST::hash_i, ST::equal_i> s_globalStates;
 uint32_t s_allPlayers = 0;
 
 #define SEND_REPLY(msg, result) \


### PR DESCRIPTION
This oversight in the extern declaration of the `s_globalStates` map apparently caused the age filenames to stored in the map with case sensitive hashes. The case insensitive hash lookup in the AuthServ then failed, causing a null State to be given to the GameHost, resulting in a crash on merging a null State.

This should fix #122.