### PR TITLE
Fix race condition in `DS::MsgChannel`.

### DIFF
--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -29,7 +29,7 @@ struct AuthClient_Private
     DS::SocketHandle m_sock;
     DS::CryptState m_crypt;
     DS::MsgChannel m_channel;
-    DS::MsgChannel m_broadcast{ false };
+    DS::MsgChannel m_broadcast;
 };
 
 struct AuthServer_PlayerInfo

--- a/AuthServ/AuthClient.h
+++ b/AuthServ/AuthClient.h
@@ -29,7 +29,7 @@ struct AuthClient_Private
     DS::SocketHandle m_sock;
     DS::CryptState m_crypt;
     DS::MsgChannel m_channel;
-    DS::MsgChannel m_broadcast;
+    DS::MsgChannel m_broadcast{ false };
 };
 
 struct AuthServer_PlayerInfo

--- a/NetIO/MsgChannel.cpp
+++ b/NetIO/MsgChannel.cpp
@@ -23,13 +23,6 @@
 #include <cstring>
 #include "errors.h"
 
-DS::MsgChannel::MsgChannel(bool initFd)
-    : m_semaphore(-1)
-{
-    if (initFd)
-        fd();
-}
-
 DS::MsgChannel::~MsgChannel()
 {
     if (m_semaphore < 0)
@@ -44,6 +37,8 @@ DS::MsgChannel::~MsgChannel()
 
 int DS::MsgChannel::fd()
 {
+    std::lock_guard<std::mutex> guard(m_mutex);
+
     if (m_semaphore >= 0)
         return m_semaphore;
 
@@ -55,12 +50,13 @@ int DS::MsgChannel::fd()
 
 void DS::MsgChannel::putMessage(int type, void* payload)
 {
-    m_queueMutex.lock();
     FifoMessage msg;
     msg.m_messageType = type;
     msg.m_payload = payload;
-    m_queue.push(msg);
-    m_queueMutex.unlock();
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        m_queue.push(msg);
+    }
 
     int result = eventfd_write(fd(), 1);
     if (result < 0)
@@ -74,15 +70,14 @@ DS::FifoMessage DS::MsgChannel::getMessage()
     if (result < 0)
         throw SystemError("Failed to read from event semaphore", strerror(errno));
 
-    m_queueMutex.lock();
+    std::lock_guard<std::mutex> guard(m_mutex);
     FifoMessage msg = m_queue.front();
     m_queue.pop();
-    m_queueMutex.unlock();
     return msg;
 }
 
 bool DS::MsgChannel::hasMessage()
 {
-    std::lock_guard<std::mutex> guard(m_queueMutex);
+    std::lock_guard<std::mutex> guard(m_mutex);
     return !m_queue.empty();
 }

--- a/NetIO/MsgChannel.cpp
+++ b/NetIO/MsgChannel.cpp
@@ -23,6 +23,13 @@
 #include <cstring>
 #include "errors.h"
 
+DS::MsgChannel::MsgChannel(bool initFd)
+    : m_semaphore(-1)
+{
+    if (initFd)
+        fd();
+}
+
 DS::MsgChannel::~MsgChannel()
 {
     if (m_semaphore < 0)

--- a/NetIO/MsgChannel.h
+++ b/NetIO/MsgChannel.h
@@ -32,7 +32,7 @@ namespace DS
     class MsgChannel
     {
     public:
-        MsgChannel() : m_semaphore(-1) { }
+        MsgChannel(bool initFd = true);
         ~MsgChannel();
 
         int fd();

--- a/NetIO/MsgChannel.h
+++ b/NetIO/MsgChannel.h
@@ -32,7 +32,7 @@ namespace DS
     class MsgChannel
     {
     public:
-        MsgChannel(bool initFd = true);
+        MsgChannel() : m_semaphore(-1) { }
         ~MsgChannel();
 
         int fd();
@@ -42,7 +42,7 @@ namespace DS
 
     private:
         int m_semaphore;
-        std::mutex m_queueMutex;
+        std::mutex m_mutex;
         std::queue<FifoMessage> m_queue;
     };
 }


### PR DESCRIPTION
In pull request #126, `DS::MsgChannel` was changed to lazy-initialize the eventfd. This is sensible because, in many places, DS uses temporary clients that do not need all MsgChannels available. Unfortunately, this introduces a potential race condition. This can be observed primarily in the `dm_game_join` handler, which pushes an `e_UpdateAgeSrv` message to the AuthDaemon. The auth server responds so quickly that there is a race between the GameHost calling `m_channel.getMessage()` and the AuthHost calling `m_channel.putMessage` that the two end up operating on different eventfds, causing the GameHost to hang forever. Anyone linking to that age from then on is permanently stuck in the spinning book age. Most other situations are not particularly vulnerable to this race condition because they do something slow, like querying postgres, giving the message pusher time to initialize the eventfd.

I made the fix to, by default, init the eventfd at `DS::MsgChannel` init, so the unsafe behavior must be opted into. In this case, the eventfd is generally requested for a `poll` operation before it is used.