### PR TITLE
Properly initialize and check SDL descriptor structures when parsing.

### DIFF
--- a/SDL/DescriptorDb.h
+++ b/SDL/DescriptorDb.h
@@ -45,6 +45,13 @@ namespace SDL
         ST::string m_string;
 
         VarDefault() : m_valid(false) { }
+
+        void clear()
+        {
+            m_valid = false;
+            m_time.setNull();
+            m_string = ST::null;
+        }
     };
 
     struct VarDescriptor
@@ -55,6 +62,19 @@ namespace SDL
         int m_size;
         VarDefault m_default;
         ST::string m_defaultOption, m_displayOption;
+
+        VarDescriptor() : m_type(e_VarInvalid), m_size() { }
+
+        void clear()
+        {
+            m_type = e_VarInvalid;
+            m_typeName = ST::null;
+            m_name = ST::null;
+            m_size = 0;
+            m_default.clear();
+            m_defaultOption = ST::null;
+            m_displayOption = ST::null;
+        }
     };
 
     struct StateDescriptor
@@ -64,6 +84,16 @@ namespace SDL
         std::vector<VarDescriptor> m_vars;
         typedef std::unordered_map<ST::string, int, ST::hash> varmap_t;
         varmap_t m_varmap;
+
+        StateDescriptor() : m_version(-1) { }
+
+        void clear()
+        {
+            m_name = ST::null;
+            m_version = -1;
+            m_vars.clear();
+            m_varmap.clear();
+        }
     };
 
     class DescriptorDb

--- a/SDL/SdlParser.cpp
+++ b/SDL/SdlParser.cpp
@@ -562,9 +562,7 @@ std::list<SDL::StateDescriptor> SDL::Parser::parse()
             } else {
                 BAD_TOK(tok.m_type, this);
             }
-            descBuffer.m_name = ST::null;
-            descBuffer.m_vars.clear();
-            descBuffer.m_version = -1;
+            descBuffer.clear();
             break;
         case e_TokVersion:
             if (state == e_State_Var /*|| state == e_State_Var_SZ*/) {
@@ -585,12 +583,7 @@ std::list<SDL::StateDescriptor> SDL::Parser::parse()
             } else {
                 BAD_TOK(tok.m_type, this);
             }
-            varBuffer.m_type = static_cast<SDL::VarType>(-1);
-            varBuffer.m_typeName = ST::null;
-            varBuffer.m_name = ST::null;
-            varBuffer.m_size = 0;
-            varBuffer.m_default.m_valid = false;
-            varBuffer.m_defaultOption = ST::null;
+            varBuffer.clear();
             break;
         case e_TokInt:
             TYPE_TOK(e_VarInt);

--- a/SDL/SdlParser.cpp
+++ b/SDL/SdlParser.cpp
@@ -17,6 +17,8 @@
 
 #include "SdlParser.h"
 
+#include <string_theory/stdio>
+
 static const char* s_toknames[] = {
     "STATEDESC", "VERSION", "VAR", "INT", "FLOAT", "BOOL", "STRING", "PLKEY",
     "CREATABLE", "DOUBLE", "TIME", "BYTE", "SHORT", "AGETIMEOFDAY", "VECTOR3",
@@ -714,6 +716,17 @@ std::list<SDL::StateDescriptor> SDL::Parser::parse()
         default:
             BAD_TOK(tok.m_type, this);
             break;
+        }
+    }
+
+    // Sanity check descriptors
+    for (auto di = descriptors.cbegin(); di != descriptors.cend(); ) {
+        if (di->m_version < 0) {
+            ST::printf(stderr, "[SDL] WARNING: A descriptor for {} has no version."
+                       "  This descriptor will be ignored!\n", di->m_name);
+            di = descriptors.erase(di);
+        } else {
+            ++di;
         }
     }
 

--- a/SDL/StateInfo.cpp
+++ b/SDL/StateInfo.cpp
@@ -539,6 +539,9 @@ void SDL::Variable::copy(const SDL::Variable& rhs) {
     case e_VarAgeTimeOfDay:
         /* No extra data to copy */
         break;
+    default:
+        DS_ASSERT(false);
+        break;
     }
 }
 

--- a/SDL/StateInfo.h
+++ b/SDL/StateInfo.h
@@ -35,6 +35,8 @@ namespace SDL
         e_VarDouble, e_VarTime, e_VarByte, e_VarShort, e_VarAgeTimeOfDay,
         e_VarVector3, e_VarPoint3, e_VarQuaternion, e_VarRgb, e_VarRgba,
         e_VarRgb8, e_VarRgba8, e_VarStateDesc,
+
+        e_VarInvalid = -1,
     };
 
     struct StateDescriptor;

--- a/Types/UnifiedTime.h
+++ b/Types/UnifiedTime.h
@@ -52,6 +52,12 @@ namespace DS
 
         void setNow();
 
+        void setNull()
+        {
+            m_secs = 0;
+            m_micros = 0;
+        }
+
     public:
         union {
             uint32_t m_secs;


### PR DESCRIPTION
This addresses both issues identified in #148.