### PR TITLE
Fix crash when reading NetGameMessages in Release.

### DIFF
--- a/PlasMOUL/Avatar/AvBrainGeneric.cpp
+++ b/PlasMOUL/Avatar/AvBrainGeneric.cpp
@@ -21,9 +21,9 @@
 MOUL::AvBrainGeneric::~AvBrainGeneric()
 {
     for (auto it = m_stages.begin(); it != m_stages.end(); ++it)
-        (*it)->unref();
-    m_startMessage->unref();
-    m_endMessage->unref();
+        Creatable::SafeUnref(*it);
+    Creatable::SafeUnref(m_startMessage);
+    Creatable::SafeUnref(m_endMessage);
 }
 
 void MOUL::AvBrainGeneric::read(DS::Stream* stream)
@@ -31,7 +31,7 @@ void MOUL::AvBrainGeneric::read(DS::Stream* stream)
     MOUL::ArmatureBrain::read(stream);
 
     for (auto it = m_stages.begin(); it != m_stages.end(); ++it)
-        (*it)->unref();
+        Creatable::SafeUnref((*it));
 
     m_stages.resize(stream->read<uint32_t>());
     for (size_t i = 0; i < m_stages.size(); ++i) {
@@ -45,13 +45,13 @@ void MOUL::AvBrainGeneric::read(DS::Stream* stream)
     m_mode = stream->read<uint8_t>();
     m_forward = stream->read<bool>();
 
-    m_startMessage->unref();
+    Creatable::SafeUnref(m_startMessage);
     if (stream->read<bool>())
         m_startMessage = Factory::Read<Message>(stream);
     else
         m_startMessage = nullptr;
 
-    m_endMessage->unref();
+    Creatable::SafeUnref(m_endMessage);
     if (stream->read<bool>())
         m_endMessage = Factory::Read<Message>(stream);
     else

--- a/PlasMOUL/Avatar/AvTask.cpp
+++ b/PlasMOUL/Avatar/AvTask.cpp
@@ -56,7 +56,7 @@ void MOUL::AvOneShotLinkTask::write(DS::Stream* stream) const
 
 void MOUL::AvTaskBrain::read(DS::Stream* stream)
 {
-    m_brain->unref();
+    Creatable::SafeUnref(m_brain);
     m_brain = Factory::Read<ArmatureBrain>(stream);
 }
 

--- a/PlasMOUL/Avatar/AvTask.h
+++ b/PlasMOUL/Avatar/AvTask.h
@@ -90,7 +90,7 @@ namespace MOUL
     protected:
         AvTaskBrain(uint16_t type) : AvTask(type), m_brain() { }
 
-        ~AvTaskBrain() override { m_brain->unref(); }
+        ~AvTaskBrain() override { Creatable::SafeUnref(m_brain); }
     };
 
     class AvTaskSeek : public AvTask

--- a/PlasMOUL/Avatar/CoopCoordinator.cpp
+++ b/PlasMOUL/Avatar/CoopCoordinator.cpp
@@ -22,9 +22,9 @@
 
 MOUL::CoopCoordinator::~CoopCoordinator()
 {
-    m_hostBrain->unref();
-    m_guestBrain->unref();
-    m_acceptMsg->unref();
+    Creatable::SafeUnref(m_hostBrain);
+    Creatable::SafeUnref(m_guestBrain);
+    Creatable::SafeUnref(m_acceptMsg);
 }
 
 void MOUL::CoopCoordinator::read(DS::Stream* s)
@@ -32,15 +32,15 @@ void MOUL::CoopCoordinator::read(DS::Stream* s)
     m_hostKey.read(s);
     m_guestKey.read(s);
 
-    m_hostBrain->unref();
-    m_guestBrain->unref();
+    Creatable::SafeUnref(m_hostBrain);
+    Creatable::SafeUnref(m_guestBrain);
     m_hostBrain = Factory::Read<AvBrainCoop>(s);
     m_guestBrain = Factory::Read<AvBrainCoop>(s);
 
     m_hostOfferStage = s->read<uint8_t>();
     m_guestAcceptStage = s->read<bool>();
 
-    m_acceptMsg->unref();
+    Creatable::SafeUnref(m_acceptMsg);
     if (s->read<bool>())
         m_acceptMsg = Factory::Read<Message>(s);
     else

--- a/PlasMOUL/Messages/AvTaskMsg.h
+++ b/PlasMOUL/Messages/AvTaskMsg.h
@@ -35,7 +35,7 @@ namespace MOUL
     protected:
         AvTaskMsg(uint16_t type) : AvatarMsg(type), m_task() { }
 
-        ~AvTaskMsg() override { m_task->unref(); }
+        ~AvTaskMsg() override { Creatable::SafeUnref(m_task); }
     };
 
     class AvPushBrainMsg : public AvTaskMsg
@@ -50,7 +50,7 @@ namespace MOUL
     protected:
         AvPushBrainMsg(uint16_t type) : AvTaskMsg(type), m_brain() { }
 
-        ~AvPushBrainMsg() override { m_brain->unref(); }
+        ~AvPushBrainMsg() override { Creatable::SafeUnref(m_brain); }
     };
 
     class AvPopBrainMsg : public AvTaskMsg

--- a/PlasMOUL/Messages/AvatarMsg.cpp
+++ b/PlasMOUL/Messages/AvatarMsg.cpp
@@ -49,7 +49,7 @@ void MOUL::AvCoopMsg::read(DS::Stream* s)
 {
     Message::read(s);
 
-    m_coordinator->unref();
+    Creatable::SafeUnref(m_coordinator);
     if (s->read<bool>())
         m_coordinator = Factory::Read<CoopCoordinator>(s);
     else

--- a/PlasMOUL/Messages/AvatarMsg.h
+++ b/PlasMOUL/Messages/AvatarMsg.h
@@ -79,7 +79,7 @@ namespace MOUL
             : Message(type), m_coordinator(), m_initiatorId(),
               m_initiatorSerial(), m_command(e_None) { }
 
-        ~AvCoopMsg() override { m_coordinator->unref(); }
+        ~AvCoopMsg() override { Creatable::SafeUnref(m_coordinator); }
     };
 
     class AvTaskSeekDoneMsg : public AvatarMsg

--- a/PlasMOUL/Messages/CreatableList.cpp
+++ b/PlasMOUL/Messages/CreatableList.cpp
@@ -26,7 +26,7 @@
 void MOUL::CreatableList::clear()
 {
     for (auto& it : m_items)
-        it.second->unref();
+        Creatable::SafeUnref(it.second);
     m_items.clear();
 }
 

--- a/PlasMOUL/Messages/LoadAvatarMsg.cpp
+++ b/PlasMOUL/Messages/LoadAvatarMsg.cpp
@@ -24,7 +24,7 @@ void MOUL::LoadAvatarMsg::read(DS::Stream* stream)
 
     m_isPlayer = stream->read<bool>();
     m_spawnPoint.read(stream);
-    m_initTask->unref();
+    Creatable::SafeUnref(m_initTask);
     if (stream->read<bool>())
         m_initTask = Factory::Read<AvTask>(stream);
     else

--- a/PlasMOUL/Messages/LoadAvatarMsg.h
+++ b/PlasMOUL/Messages/LoadAvatarMsg.h
@@ -40,7 +40,7 @@ namespace MOUL
         LoadAvatarMsg(uint16_t type)
             : LoadCloneMsg(type), m_isPlayer(true), m_initTask() { }
 
-        ~LoadAvatarMsg() override { m_initTask->unref(); }
+        ~LoadAvatarMsg() override { Creatable::SafeUnref(m_initTask); }
     };
 }
 

--- a/PlasMOUL/Messages/LoadCloneMsg.cpp
+++ b/PlasMOUL/Messages/LoadCloneMsg.cpp
@@ -28,7 +28,7 @@ void MOUL::LoadCloneMsg::read(DS::Stream* stream)
     m_userData = stream->read<uint32_t>();
     m_validMsg = stream->read<bool>();
     m_isLoading = stream->read<bool>();
-    m_triggerMsg->unref();
+    Creatable::SafeUnref(m_triggerMsg);
     m_triggerMsg = Factory::Read<Message>(stream);
 }
 

--- a/PlasMOUL/Messages/LoadCloneMsg.h
+++ b/PlasMOUL/Messages/LoadCloneMsg.h
@@ -40,7 +40,7 @@ namespace MOUL
             : Message(type), m_validMsg(), m_isLoading(),
               m_userData(), m_originPlayerId(), m_triggerMsg() { }
 
-        ~LoadCloneMsg() override { m_triggerMsg->unref(); }
+        ~LoadCloneMsg() override { Creatable::SafeUnref(m_triggerMsg); }
     };
 }
 

--- a/PlasMOUL/Messages/MessageWithCallbacks.cpp
+++ b/PlasMOUL/Messages/MessageWithCallbacks.cpp
@@ -21,7 +21,7 @@
 MOUL::MessageWithCallbacks::~MessageWithCallbacks()
 {
     for (Message* callback : m_callbacks)
-        callback->unref();
+        Creatable::SafeUnref(callback);
 }
 
 void MOUL::MessageWithCallbacks::read(DS::Stream* stream)
@@ -29,7 +29,7 @@ void MOUL::MessageWithCallbacks::read(DS::Stream* stream)
     Message::read(stream);
 
     for (Message* callback : m_callbacks)
-        callback->unref();
+        Creatable::SafeUnref(callback);
 
     m_callbacks.resize(stream->read<uint32_t>());
     for (size_t i = 0; i < m_callbacks.capacity(); ++i)

--- a/PlasMOUL/NetMessages/NetMsgGameMessage.cpp
+++ b/PlasMOUL/NetMessages/NetMsgGameMessage.cpp
@@ -25,7 +25,7 @@ void MOUL::NetMsgGameMessage::read(DS::Stream* stream)
     NetMsgStream msgStream;
     msgStream.read(stream);
     m_compression = msgStream.m_compression;
-    m_message->unref();
+    Creatable::SafeUnref(m_message);
     m_message = Factory::Read<Message>(&msgStream.m_stream);
 
     if (stream->read<bool>())

--- a/PlasMOUL/NetMessages/NetMsgGameMessage.h
+++ b/PlasMOUL/NetMessages/NetMsgGameMessage.h
@@ -39,7 +39,7 @@ namespace MOUL
             : NetMessage(type), m_compression(NetMsgStream::e_CompressNone),
               m_message() { }
 
-        ~NetMsgGameMessage() override { m_message->unref(); }
+        ~NetMsgGameMessage() override { Creatable::SafeUnref(m_message); }
     };
 
     class NetMsgGameMessageDirected : public NetMsgGameMessage

--- a/PlasMOUL/creatable.h
+++ b/PlasMOUL/creatable.h
@@ -38,7 +38,7 @@ namespace MOUL
 
     class Creatable
     {
-        static void safe_unref(Creatable* pcre)
+        static void __attribute__ ((noinline)) safe_unref(Creatable* pcre)
         {
             if (pcre && --pcre->m_refs == 0)
                 delete pcre;

--- a/PlasMOUL/creatable.h
+++ b/PlasMOUL/creatable.h
@@ -38,12 +38,6 @@ namespace MOUL
 
     class Creatable
     {
-        static void __attribute__ ((noinline)) safe_unref(Creatable* pcre)
-        {
-            if (pcre && --pcre->m_refs == 0)
-                delete pcre;
-        }
-
     public:
         template <class cre_t> cre_t* Cast()
         { return dynamic_cast<cre_t*>(this); }
@@ -54,7 +48,23 @@ namespace MOUL
         uint16_t type() const { return m_type; }
 
         void ref() { ++m_refs; }
-        void unref() { safe_unref(this); }
+        void unref()
+        {
+            if (--m_refs == 0)
+                delete this;
+        }
+
+        static void SafeRef(Creatable* const pCre)
+        {
+            if (pCre)
+                pCre->ref();
+        }
+
+        static void SafeUnref(Creatable* const pCre)
+        {
+            if (pCre)
+                pCre->unref();
+        }
 
         virtual void read(DS::Stream* stream) { }
         virtual void write(DS::Stream* stream) const { }

--- a/SDL/StateInfo.cpp
+++ b/SDL/StateInfo.cpp
@@ -141,7 +141,7 @@ void SDL::Variable::_ref::clear()
         break;
     case e_VarCreatable:
         for (int i=0; i<m_desc->m_size; ++i)
-            m_creatable[i]->unref();
+            MOUL::Creatable::SafeUnref(m_creatable[i]);
         delete[] m_creatable;
         break;
     case e_VarDouble:
@@ -498,8 +498,8 @@ void SDL::Variable::copy(const SDL::Variable& rhs) {
         break;
     case e_VarCreatable:
         for (size_t i = 0; i < minsize; ++i) {
-            rhs.m_data->m_creatable[i]->ref();
-            m_data->m_creatable[i]->unref();
+            MOUL::Creatable::SafeRef(rhs.m_data->m_creatable[i]);
+            MOUL::Creatable::SafeUnref(m_data->m_creatable[i]);
             m_data->m_creatable[i] = rhs.m_data->m_creatable[i];
         }
         break;
@@ -656,7 +656,7 @@ void SDL::Variable::setDefault()
             m_data->m_key[i] = MOUL::Uoid();
             break;
         case e_VarCreatable:
-            m_data->m_creatable[i]->unref();
+            MOUL::Creatable::SafeUnref(m_data->m_creatable[i]);
             m_data->m_creatable[i] = nullptr;
             break;
         case e_VarDouble:


### PR DESCRIPTION
GCC very kindly inlines `safe_unref` for us, which causes the `if (pcre)` statement to evaluate to `if (this)`, which is optimized away.