### PR TITLE
Fix race condition.

### DIFF
--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -443,12 +443,11 @@ void DS::GameServer_UpdateGlobalSDL(const ST::string& age)
 
 bool DS::GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId)
 {
-    s_gameHostMutex.lock();
+    std::lock_guard<std::mutex> lock(s_gameHostMutex);
     hostmap_t::iterator host_iter = s_gameHosts.find(ageMcpId);
     GameHost_Private* host = nullptr;
     if (host_iter != s_gameHosts.end())
         host = host_iter->second;
-    s_gameHostMutex.unlock();
 
     if (host) {
         GameClient_Private client;


### PR DESCRIPTION
This has been observed to deadlock the server. Bug was introduced in #156. Ideally, this weird "save the Age blob to the vault" hack needs to go away, but that will be for another PR.