### PR TITLE
Deadlock Fix: Part Deux

### DIFF
--- a/GameServ/GameHost.cpp
+++ b/GameServ/GameHost.cpp
@@ -773,13 +773,15 @@ void dm_local_sdl_update(GameHost_Private* host, Game_SdlMessage* msg)
     sdlNode.m_internal = true;
     sdlNode.m_node = std::move(msg->m_node);
     sdlNode.m_revision.clear();
+
+    // The client that put this message is the auth daemon, and it is blocking on us.
+    SEND_REPLY(msg, DS::e_NetSuccess);
+
     s_authChannel.putMessage(e_VaultUpdateNode, reinterpret_cast<void*>(&sdlNode));
     if (fakeClient.m_channel.getMessage().m_messageType != DS::e_NetSuccess)
         fputs("[Game] Error writing SDL node back to vault\n", stderr);
 
     dm_bcast_agesdl_hook(host);
-
-    SEND_REPLY(msg, DS::e_NetSuccess);
 }
 
 void dm_global_sdl_update(GameHost_Private* host)

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -441,7 +441,7 @@ void DS::GameServer_UpdateGlobalSDL(const ST::string& age)
 }
 
 
-bool DS::GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId)
+uint32_t DS::GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId)
 {
     std::lock_guard<std::mutex> lock(s_gameHostMutex);
     hostmap_t::iterator host_iter = s_gameHosts.find(ageMcpId);
@@ -456,12 +456,12 @@ bool DS::GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpI
         msg.m_node = node.copy();
         try {
             host->m_channel.putMessage(e_GameLocalSdlUpdate, &msg);
-            return client.m_channel.getMessage().m_messageType == DS::e_NetSuccess;
+            return client.m_channel.getMessage().m_messageType;
         } catch (const std::exception& ex) {
             ST::printf(stderr, "[Game] WARNING: {}\n", ex.what());
         }
     }
-    return false;
+    return DS::e_NetAgeNotFound;
 }
 
 void DS::GameServer_DisplayClients()

--- a/GameServ/GameServer.h
+++ b/GameServ/GameServer.h
@@ -33,7 +33,7 @@ namespace DS
     void GameServer_Shutdown();
 
     void GameServer_UpdateGlobalSDL(const ST::string& age);
-    bool GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId);
+    uint32_t GameServer_UpdateVaultSDL(const DS::Vault::Node& node, uint32_t ageMcpId);
 
     void GameServer_DisplayClients();
     uint32_t GameServer_GetNumClients(Uuid instance);


### PR DESCRIPTION
OK, this is what happens when you don't test your claim before you make a PR 🙄

#158 only handled part of the story. The issue I was seeing was that the auth thread submitted a vault SDL update to the gameserver, which submitted that update back to the vault. So, I've made sure the game thread unblocks the auth thread before submitting the vault SDL update back to the auth daemon. Also, I've cleaned up a problem where "no running game server" was being interpreted as "error".