### PR TITLE
Add new static fan Ages.

### DIFF
--- a/static_ages.ini
+++ b/static_ages.ini
@@ -42,6 +42,16 @@ Instance = Phil's Relto
 Filename = philRelto
 UserName =
 
+[0b4f5ad9-d93d-52e3-83e4-9364c2149ae4]
+Instance = Chiso Preniv
+Filename = ChisoPreniv
+UserName =
+
+[d002da26-db26-53f1-bdc0-a05a84274d5c]
+Instance = New Messengers' Pub
+Filename = GoMePubNew
+UserName =
+
 [auto]
 Instance = Watcher's Pub
 Filename = GreatTreePub


### PR DESCRIPTION
Update static_ages.ini to current.

These UUIDs were generated by me for these fan Ages. The general rule is to use a UUIDv5 of the Age's filename with the namespace being the client UUID. Unfortunately, 0b4f5ad9-d93d-52e3-83e4-9364c2149ae4 was generated before I knew the actual filename of ChisoPreniv (the UUID was generated with Chiso).