### PR TITLE
Fix proVariableEvent string reading/writing.

### DIFF
--- a/PlasMOUL/Messages/EventData.cpp
+++ b/PlasMOUL/Messages/EventData.cpp
@@ -135,7 +135,7 @@ void MOUL::ControlKeyEventData::write(DS::Stream* stream) const
 
 void MOUL::VariableEventData::read(DS::Stream* stream)
 {
-    m_name = stream->readSafeString();
+    m_name = stream->readSafeString(DS::e_StringUTF8);
     m_dataType = stream->read<EventDataType, uint32_t>();
     switch(m_dataType) {
     case e_DataFloat:
@@ -152,7 +152,7 @@ void MOUL::VariableEventData::read(DS::Stream* stream)
 
 void MOUL::VariableEventData::write(DS::Stream* stream) const
 {
-    stream->writeSafeString(m_name);
+    stream->writeSafeString(m_name, DS::e_StringUTF8);
     stream->write<EventDataType, uint32_t>(m_dataType);
     switch(m_dataType) {
     case e_DataFloat:


### PR DESCRIPTION
This crashes the server when visiting the Neighborhood with a player whose name contains non-ASCII characters.... Although, in my experience it has caused a weird game host deadlock instead of a full-blown crash. All hail address sanitizer for helping me find this.

A more general question, though... It looks like in Plasma safe strings are now assumed to be UTF-8 by default while DS is assuming latin_1 by default. I think, in years past, DS's assumption matched Plasma's, but that seems to no longer be the case. Should we consider switching the default string format to `e_StringUTF8`?