### PR TITLE
Fix compatibility with older CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ set(dirtsand_SOURCES
     settings.cpp
 )
 
-add_library(dirtsand OBJECT ${dirtsand_SOURCES} ${SDL_SOURCES} ${PlasMOUL_SOURCES})
+add_library(dirtsand STATIC ${dirtsand_SOURCES} ${SDL_SOURCES} ${PlasMOUL_SOURCES})
 
 target_compile_definitions(dirtsand PRIVATE
     $<$<CONFIG:Debug>:DEBUG>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,15 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/bin/docker-entrypoint.sh ${CMAKE_SOURCE_DIR
 install(FILES static_ages.ini
         DESTINATION ".")
 
-option(ENABLE_TESTS "Enable building and running unit tests" ON)
+# The tests use the FetchContent module, which was added in CMake 3.11.
+include(CMakeDependentOption)
+cmake_dependent_option(
+    ENABLE_TESTS
+    "Enable building and running unit tests"
+    ON
+    "NOT ${CMAKE_VERSION} VERSION_LESS 3.11"
+    OFF
+)
 
 # clang-tidy related rules and targets
 include(TidyRules.cmake)


### PR DESCRIPTION
Now works again with at least CMake 3.7.2.