### PR TITLE
Reduce unnecessary heap allocations and copies in manifest code

### DIFF
--- a/AuthServ/AuthManifest.h
+++ b/AuthServ/AuthManifest.h
@@ -26,6 +26,14 @@ namespace DS
 {
     struct AuthFileInfo
     {
+        AuthFileInfo() : m_fileSize() { }
+
+        AuthFileInfo(const AuthFileInfo&) = delete;
+        AuthFileInfo& operator=(const AuthFileInfo&) = delete;
+
+        AuthFileInfo(AuthFileInfo&&) = default;
+        AuthFileInfo& operator=(AuthFileInfo&&) = default;
+
         ST::string m_filename;
         uint32_t m_fileSize;
     };
@@ -34,7 +42,6 @@ namespace DS
     {
     public:
         AuthManifest() { }
-        ~AuthManifest();
 
         NetResultCode loadManifest(const char* filename);
         uint32_t encodeToStream(DS::Stream* stream) const;
@@ -42,7 +49,7 @@ namespace DS
         size_t fileCount() const { return m_files.size(); }
 
     private:
-        std::list<AuthFileInfo*> m_files;
+        std::vector<AuthFileInfo> m_files;
     };
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(dirtsand)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set up Product Identification parameters (NOTE: Should match plClient)

--- a/FileServ/FileManifest.h
+++ b/FileServ/FileManifest.h
@@ -26,6 +26,16 @@ namespace DS
 {
     struct FileInfo
     {
+        FileInfo()
+            : m_fileHash(), m_downloadHash(), m_fileSize(), m_downloadSize(),
+              m_flags() { }
+
+        FileInfo(const FileInfo&) = delete;
+        FileInfo& operator=(const FileInfo&) = delete;
+
+        FileInfo(FileInfo&&) = default;
+        FileInfo& operator=(FileInfo&&) = default;
+
         ST::string m_filename, m_downloadName;
         char16_t m_fileHash[32], m_downloadHash[32];
         uint32_t m_fileSize, m_downloadSize;
@@ -35,16 +45,13 @@ namespace DS
     class FileManifest
     {
     public:
-        FileManifest() { }
-        ~FileManifest();
-
         NetResultCode loadManifest(const char* filename);
         uint32_t encodeToStream(DS::Stream* stream) const;
 
         size_t fileCount() const { return m_files.size(); }
 
     private:
-        std::list<FileInfo*> m_files;
+        std::vector<FileInfo> m_files;
     };
 }
 


### PR DESCRIPTION
Note: Taking a reference from `emplace_back()` requires a bump to C++17.  It's probably time to do that anyway...