### PR TITLE
Two fixes for email-based authentication

### DIFF
--- a/NetIO/CryptIO.cpp
+++ b/NetIO/CryptIO.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <mutex>
 #include <memory>
+#include <regex>
 
 #ifdef DEBUG
 bool s_commdebug = false;
@@ -263,4 +264,12 @@ DS::ShaHash DS::BuggyHashLogin(const ShaHash& passwordHash, uint32_t serverChall
     buffer.m_serverChallenge = serverChallenge;
     buffer.m_pwhash = passwordHash;
     return ShaHash::Sha0(&buffer, sizeof(buffer));
+}
+
+bool DS::UseEmailAuth(const ST::string& username)
+{
+    static const std::regex re_domain("[^@]+@([^.]+\\.)*([^.]+)\\.[^.]+");
+    std::cmatch match;
+    std::regex_search(username.c_str(), match, re_domain);
+    return !match.empty() && ST::string(match[2].str().c_str()).compare_i("gametap") != 0;
 }

--- a/NetIO/CryptIO.h
+++ b/NetIO/CryptIO.h
@@ -79,6 +79,7 @@ namespace DS
     ShaHash BuggyHashPassword(const ST::string& username, const ST::string& password);
     ShaHash BuggyHashLogin(const ShaHash& passwordHash, uint32_t serverChallenge,
                            uint32_t clientChallenge);
+    bool UseEmailAuth(const ST::string& username);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
1) Fix the conditional for gametap domains to use the same regular expression that the client uses.  It might have otherwise picked the wrong branch for some cases (e.g. "foo@bar" or "me@tld.gametap.com").
2) Actually use `BuggyHashPassword` when creating an account with an email-based username.  Previously, `BuggyHashPassword` wasn't ever used anywhere, and the SHA-1 hash was used unconditionally when adding accounts.