### PR TITLE
Minor Auth/SDL Fixes.

### DIFF
--- a/AuthServ/AuthServer_Private.h
+++ b/AuthServ/AuthServer_Private.h
@@ -89,6 +89,12 @@ enum AuthServer_MsgIds
 enum ServerCaps
 {
     e_CapsScoreLeaderBoards,
+    e_CapsGameMgrBlueSpiral,
+    e_CapsGameMgrClimbingWall,
+    e_CapsGameMgrHeek,
+    e_CapsGameMgrMarker,
+    e_CapsGameMgrTTT,
+    e_CapsGameMgrVarSync,
 };
 
 struct AuthServer_Private : public AuthClient_Private

--- a/SDL/StateInfo.h
+++ b/SDL/StateInfo.h
@@ -32,10 +32,10 @@ namespace SDL
 {
     enum VarType
     {
-        e_VarInt, e_VarFloat, e_VarBool, e_VarString, e_VarKey, e_VarCreatable,
-        e_VarDouble, e_VarTime, e_VarByte, e_VarShort, e_VarAgeTimeOfDay,
-        e_VarVector3, e_VarPoint3, e_VarQuaternion, e_VarRgb, e_VarRgba,
-        e_VarRgb8, e_VarRgba8, e_VarStateDesc,
+        e_VarInt, e_VarFloat, e_VarBool, e_VarString, e_VarKey, e_VarStateDesc,
+        e_VarCreatable, e_VarDouble, e_VarTime, e_VarByte, e_VarShort, e_VarAgeTimeOfDay,
+        e_VarVector3, e_VarPoint3, e_VarRgb, e_VarRgba, e_VarQuaternion,
+        e_VarRgb8, e_VarRgba8,
 
         e_VarInvalid = -1,
     };


### PR DESCRIPTION
A couple of minor fixes:
- Update the ServerCaps enumeration to match what's currently in the client due to GameMgr work. DS still doesn't support the GameMgr, so this is unused.
- Change the SDL variable type numeration to match the client exactly. This is never sent to the client, but it theoretically *could* be due to the client having read/write methods for `plStateDescriptor`.