### PR TITLE
Send DS's SDL to clients from the AuthSrv

### DIFF
--- a/AuthServ/AuthManifest.h
+++ b/AuthServ/AuthManifest.h
@@ -27,6 +27,9 @@ namespace DS
     struct AuthFileInfo
     {
         AuthFileInfo() : m_fileSize() { }
+        AuthFileInfo(ST::string filename, uint32_t fileSize)
+            : m_filename(std::move(filename)), m_fileSize(fileSize)
+        { }
 
         AuthFileInfo(const AuthFileInfo&) = delete;
         AuthFileInfo& operator=(const AuthFileInfo&) = delete;
@@ -47,6 +50,11 @@ namespace DS
         uint32_t encodeToStream(DS::Stream* stream) const;
 
         size_t fileCount() const { return m_files.size(); }
+
+        void addFile(ST::string filename, uint32_t fileSize)
+        {
+            m_files.emplace_back(std::move(filename), fileSize);
+        }
 
     private:
         std::vector<AuthFileInfo> m_files;

--- a/AuthServ/AuthServer_Private.h
+++ b/AuthServ/AuthServer_Private.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <thread>
 #include <mutex>
+#include <memory>
 
 enum AuthServer_MsgIds
 {
@@ -105,18 +106,9 @@ struct AuthServer_Private : public AuthClient_Private
     uint32_t m_acctFlags;
     AuthServer_PlayerInfo m_player;
     uint32_t m_ageNodeId;
-    std::map<uint32_t, DS::Stream*> m_downloads;
+    std::map<uint32_t, std::unique_ptr<DS::Stream>> m_downloads;
 
     AuthServer_Private() : m_serverChallenge(0), m_acctFlags(0), m_ageNodeId(0) { }
-
-    ~AuthServer_Private()
-    {
-        while (!m_downloads.empty()) {
-            auto item = m_downloads.begin();
-            delete item->second;
-            m_downloads.erase(item);
-        }
-    }
 };
 
 extern std::list<AuthServer_Private*> s_authClients;

--- a/SDL/DescriptorDb.cpp
+++ b/SDL/DescriptorDb.cpp
@@ -30,46 +30,39 @@ static int sel_sdl(const dirent* de)
 
 SDL::DescriptorDb::descmap_t SDL::DescriptorDb::s_descriptors;
 
+bool SDL::DescriptorDb::LoadDescriptorsFromFile(const ST::string& filename)
+{
+    SDL::Parser parser;
+    if (parser.open(filename.c_str())) {
+        std::list<StateDescriptor> descriptors = parser.parse();
+        for (auto it = descriptors.begin(); it != descriptors.end(); ++it) {
+#ifdef DEBUG
+            descmap_t::iterator namei = s_descriptors.find(it->m_name);
+            if (namei != s_descriptors.end()) {
+                if (namei->second.find(it->m_version) != namei->second.end()) {
+                    ST::printf(stderr, "[SDL] Warning: Duplicate descriptor version for {}\n",
+                               it->m_name);
+                }
+            }
+#endif
+            s_descriptors[it->m_name][it->m_version] = *it;
+
+            // Keep the highest version in -1
+            if (s_descriptors[it->m_name][-1].m_version < it->m_version)
+                s_descriptors[it->m_name][-1] = *it;
+        }
+    }
+    return true;
+}
+
 bool SDL::DescriptorDb::LoadDescriptors(const char* sdlpath)
 {
-    dirent** dirls;
-    int count = scandir(sdlpath, &dirls, &sel_sdl, &alphasort);
-    if (count < 0) {
-        ST::printf(stderr, "[SDL] Error reading SDL descriptors: {}\n", strerror(errno));
+    try {
+        ForDescriptorFiles(sdlpath, LoadDescriptorsFromFile);
+    } catch (const DS::SystemError& err) {
+        fputs(err.what(), stderr);
         return false;
     }
-    if (count == 0) {
-        fputs("[SDL] Warning: No SDL descriptors found!\n", stderr);
-        free(dirls);
-        return true;
-    }
-
-    SDL::Parser parser;
-    for (int i=0; i<count; ++i) {
-        ST::string filename = ST::format("{}/{}", sdlpath, dirls[i]->d_name);
-        if (parser.open(filename.c_str())) {
-            std::list<StateDescriptor> descriptors = parser.parse();
-            for (auto it = descriptors.begin(); it != descriptors.end(); ++it) {
-#ifdef DEBUG
-                descmap_t::iterator namei = s_descriptors.find(it->m_name);
-                if (namei != s_descriptors.end()) {
-                    if (namei->second.find(it->m_version) != namei->second.end()) {
-                        ST::printf(stderr, "[SDL] Warning: Duplicate descriptor version for {}\n",
-                                   it->m_name);
-                    }
-                }
-#endif
-                s_descriptors[it->m_name][it->m_version] = *it;
-
-                // Keep the highest version in -1
-                if (s_descriptors[it->m_name][-1].m_version < it->m_version)
-                    s_descriptors[it->m_name][-1] = *it;
-            }
-        }
-        parser.close();
-        free(dirls[i]);
-    }
-    free(dirls);
     return true;
 }
 
@@ -124,3 +117,27 @@ bool SDL::DescriptorDb::ForLatestDescriptors(descfunc_t functor)
     return true;
 }
 
+bool SDL::DescriptorDb::ForDescriptorFiles(const char* sdlpath, const filefunc_t& functor)
+{
+    dirent** dirls;
+    int count = scandir(sdlpath, &dirls, &sel_sdl, &alphasort);
+
+    DS_ASSERT(count > 0);
+    if (count == 0)
+        fputs("[SDL] Warning: No SDL descriptors found!\n", stderr);
+    if (count < 0)
+        throw DS::SystemError("[SDL] Error scanning for SDL files", strerror(errno));
+
+    bool retval = true;
+    for (int i = 0; i < count; i++) {
+        if (!functor(ST::format("{}/{}", sdlpath, dirls[i]->d_name))) {
+            retval = false;
+            break;
+        }
+    }
+
+    for (int i = 0; i < count; i++)
+        free(dirls[i]);
+    free(dirls);
+    return retval;
+}

--- a/SDL/DescriptorDb.cpp
+++ b/SDL/DescriptorDb.cpp
@@ -117,7 +117,7 @@ bool SDL::DescriptorDb::ForLatestDescriptors(descfunc_t functor)
     return true;
 }
 
-bool SDL::DescriptorDb::ForDescriptorFiles(const char* sdlpath, const filefunc_t& functor)
+bool SDL::DescriptorDb::ForDescriptorFiles(const char* sdlpath, filefunc_t functor)
 {
     dirent** dirls;
     int count = scandir(sdlpath, &dirls, &sel_sdl, &alphasort);

--- a/SDL/DescriptorDb.h
+++ b/SDL/DescriptorDb.h
@@ -100,16 +100,20 @@ namespace SDL
     {
     public:
         typedef std::function<bool(const ST::string&, StateDescriptor*)> descfunc_t;
+        typedef std::function<bool(ST::string path)> filefunc_t;
 
         static bool LoadDescriptors(const char* sdlpath);
         static StateDescriptor* FindDescriptor(const ST::string& name, int version);
         static StateDescriptor* FindLatestDescriptor(const ST::string& name);
         static bool ForLatestDescriptors(descfunc_t functor);
+        static bool ForDescriptorFiles(const char* sdlpath, const filefunc_t& functor);
 
     private:
         DescriptorDb() = delete;
         DescriptorDb(const DescriptorDb&) = delete;
         ~DescriptorDb() = delete;
+
+        static bool LoadDescriptorsFromFile(const ST::string& path);
 
         typedef std::unordered_map<int, StateDescriptor> versionmap_t;
         typedef std::unordered_map<ST::string, versionmap_t, ST::hash_i, ST::equal_i> descmap_t;

--- a/SDL/DescriptorDb.h
+++ b/SDL/DescriptorDb.h
@@ -106,7 +106,7 @@ namespace SDL
         static StateDescriptor* FindDescriptor(const ST::string& name, int version);
         static StateDescriptor* FindLatestDescriptor(const ST::string& name);
         static bool ForLatestDescriptors(descfunc_t functor);
-        static bool ForDescriptorFiles(const char* sdlpath, const filefunc_t& functor);
+        static bool ForDescriptorFiles(const char* sdlpath, filefunc_t functor);
 
     private:
         DescriptorDb() = delete;

--- a/SDL/SdlParser.cpp
+++ b/SDL/SdlParser.cpp
@@ -55,7 +55,7 @@ bool SDL::Parser::open(const char* filename)
             close();
             return false;
         }
-        if (m_encStream->getEncType() == DS::EncryptedStream::Type::e_btea)
+        if (m_encStream->getEncType() == DS::EncryptedStream::Type::e_xxtea)
             m_encStream->setKeys(DS::Settings::DroidKey());
     }
 

--- a/SDL/SdlParser.cpp
+++ b/SDL/SdlParser.cpp
@@ -44,6 +44,7 @@ bool SDL::Parser::open(const char* filename)
         m_fileStream->open(filename, "r");
     } catch (DS::FileIOException& ex) {
         ST::printf(stderr, "[SDL] Error opening file {} for reading: {}\n", filename, ex.what());
+        close();
         return false;
     }
 

--- a/SDL/SdlParser.h
+++ b/SDL/SdlParser.h
@@ -20,8 +20,14 @@
 
 #include "DescriptorDb.h"
 #include "strings.h"
-#include <cstdio>
 #include <list>
+
+namespace DS
+{
+    class EncryptedStream;
+    class FileStream;
+    class Stream;
+}
 
 namespace SDL
 {
@@ -50,18 +56,11 @@ namespace SDL
     class Parser
     {
     public:
-        Parser() : m_file(), m_lineno(-1) { }
+        Parser() : m_fileStream(), m_encStream(), m_lineno(-1) { }
         ~Parser() { close(); }
 
         bool open(const char* filename);
-        void close()
-        {
-            if (m_file)
-                fclose(m_file);
-            m_file = nullptr;
-            m_filename.clear();
-            m_lineno = -1;
-        }
+        void close();
 
         const char* filename() const { return m_filename.c_str(); }
 
@@ -71,10 +70,13 @@ namespace SDL
         std::list<StateDescriptor> parse();
 
     private:
-        FILE* m_file;
+        DS::FileStream* m_fileStream;
+        DS::EncryptedStream* m_encStream;
         ST::string m_filename;
         long m_lineno;
         std::list<Token> m_buffer;
+
+        DS::Stream* stream() const;
     };
 }
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -8,6 +8,7 @@ FetchContent_MakeAvailable(Catch2)
 
 set(test_SOURCES
     main.cpp
+    Test_EncryptedStream.cpp
     Test_Location.cpp
     Test_SDL.cpp
     Test_ShaHash.cpp

--- a/Tests/Test_EncryptedStream.cpp
+++ b/Tests/Test_EncryptedStream.cpp
@@ -25,7 +25,7 @@ TEST_CASE("EncryptedStream known values", "[streams]")
     const char result[] = "Hello, world!";
     constexpr size_t resultsz = sizeof(result) - 1;
 
-    SECTION("bTEA") {
+    SECTION("xxtea") {
         uint32_t keys[] = { 0x31415926, 0x53589793, 0x23846264, 0x33832795 };
         uint8_t buff[] = {
             0x6E, 0x6F, 0x74, 0x74, 0x68, 0x65, 0x64, 0x72, 0x6F, 0x69, 0x64, 0x73,
@@ -35,7 +35,7 @@ TEST_CASE("EncryptedStream known values", "[streams]")
 
         DS::BufferStream base(buff, sizeof(buff));
         DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_read, std::nullopt, keys);
-        REQUIRE(stream.getEncType() == DS::EncryptedStream::Type::e_btea);
+        REQUIRE(stream.getEncType() == DS::EncryptedStream::Type::e_xxtea);
         REQUIRE(stream.size() == resultsz);
 
         char test[sizeof(result)];
@@ -47,7 +47,7 @@ TEST_CASE("EncryptedStream known values", "[streams]")
         REQUIRE(stream.atEof());
     }
 
-    SECTION("xTEA") {
+    SECTION("tea") {
         uint8_t buff[] = {
             0x77, 0x68, 0x61, 0x74, 0x64, 0x6F, 0x79, 0x6F, 0x75, 0x73, 0x65, 0x65,
             0x0D, 0x00, 0x00, 0x00, 0xAC, 0xC1, 0xA6, 0xB6, 0xDC, 0x33, 0x95, 0x0E,
@@ -56,7 +56,7 @@ TEST_CASE("EncryptedStream known values", "[streams]")
 
         DS::BufferStream base(buff, sizeof(buff));
         DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_read);
-        REQUIRE(stream.getEncType() == DS::EncryptedStream::Type::e_xtea);
+        REQUIRE(stream.getEncType() == DS::EncryptedStream::Type::e_tea);
         REQUIRE(stream.size() == resultsz);
 
         char test[sizeof(result)];
@@ -82,8 +82,8 @@ TEST_CASE("EncryptedStream known values", "[streams]")
 
 TEST_CASE("EncryptedStream round-trip", "[streams]",) {
     auto type = GENERATE(
-        DS::EncryptedStream::Type::e_btea,
-        DS::EncryptedStream::Type::e_xtea
+        DS::EncryptedStream::Type::e_xxtea,
+        DS::EncryptedStream::Type::e_tea
     );
 
     DS::BufferStream base;
@@ -114,18 +114,18 @@ TEST_CASE("EncryptedStream Magic Strings", "[streams]")
     SECTION("whatdoyousee") {
         const char buffer[] { "whatdoyousee\x0\x0\x0\x0" };
         DS::BufferStream base(buffer, sizeof(buffer));
-        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_xtea);
+        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_tea);
     }
 
     SECTION("BriceIsSmart") {
         const char buffer[] { "BriceIsSmart\x0\x0\x0\x0" };
         DS::BufferStream base(buffer, sizeof(buffer));
-        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_xtea);
+        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_tea);
     }
 
     SECTION("notthedroids") {
         const char buffer[] { "notthedroids\x0\x0\x0\x0" };
         DS::BufferStream base(buffer, sizeof(buffer));
-        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_btea);
+        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_xxtea);
     }
 }

--- a/Tests/Test_EncryptedStream.cpp
+++ b/Tests/Test_EncryptedStream.cpp
@@ -1,0 +1,131 @@
+/******************************************************************************
+ * This file is part of dirtsand.                                             *
+ *                                                                            *
+ * dirtsand is free software: you can redistribute it and/or modify           *
+ * it under the terms of the GNU Affero General Public License as             *
+ * published by the Free Software Foundation, either version 3 of the         *
+ * License, or (at your option) any later version.                            *
+ *                                                                            *
+ * dirtsand is distributed in the hope that it will be useful,                *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU Affero General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Affero General Public License   *
+ * along with dirtsand.  If not, see <http://www.gnu.org/licenses/>.          *
+ ******************************************************************************/
+
+#include "streams.h"
+
+#include <catch2/catch.hpp>
+#include <tuple>
+
+TEST_CASE("EncryptedStream known values", "[streams]")
+{
+    const char result[] = "Hello, world!";
+    constexpr size_t resultsz = sizeof(result) - 1;
+
+    SECTION("bTEA") {
+        uint32_t keys[] = { 0x31415926, 0x53589793, 0x23846264, 0x33832795 };
+        uint8_t buff[] = {
+            0x6E, 0x6F, 0x74, 0x74, 0x68, 0x65, 0x64, 0x72, 0x6F, 0x69, 0x64, 0x73,
+            0x0D, 0x00, 0x00, 0x00, 0x93, 0xBD, 0x71, 0x93, 0xA4, 0x40, 0xC2, 0x6A,
+            0x37, 0xD1, 0xA7, 0x9E, 0xEA, 0x93, 0x45, 0xC9
+        };
+
+        DS::BufferStream base(buff, sizeof(buff));
+        DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_read, std::nullopt, keys);
+        REQUIRE(stream.getEncType() == DS::EncryptedStream::Type::e_btea);
+        REQUIRE(stream.size() == resultsz);
+
+        char test[sizeof(result)];
+        stream.readBytes(test, resultsz);
+        test[sizeof(test) - 1] = 0;
+        CAPTURE(test);
+        REQUIRE(memcmp(test, result, resultsz) == 0);
+
+        REQUIRE(stream.atEof());
+    }
+
+    SECTION("xTEA") {
+        uint8_t buff[] = {
+            0x77, 0x68, 0x61, 0x74, 0x64, 0x6F, 0x79, 0x6F, 0x75, 0x73, 0x65, 0x65,
+            0x0D, 0x00, 0x00, 0x00, 0xAC, 0xC1, 0xA6, 0xB6, 0xDC, 0x33, 0x95, 0x0E,
+            0x99, 0x18, 0xAE, 0xFC, 0x9C, 0xD3, 0x00, 0xB9
+        };
+
+        DS::BufferStream base(buff, sizeof(buff));
+        DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_read);
+        REQUIRE(stream.getEncType() == DS::EncryptedStream::Type::e_xtea);
+        REQUIRE(stream.size() == resultsz);
+
+        char test[sizeof(result)];
+        stream.readBytes(test, resultsz);
+        test[sizeof(test) - 1] = 0;
+        CAPTURE(test);
+        REQUIRE(memcmp(test, result, resultsz) == 0);
+
+        REQUIRE(stream.atEof());
+    }
+}
+
+#define WRITE_STRING(_stream, _str)                                           \
+    _stream.writeBytes(_str, sizeof(_str) - 1);
+
+#define CHECK_STRING(_stream, _str)                                           \
+    {                                                                         \
+        constexpr size_t bufsz = sizeof(_str) - 1;                            \
+        uint8_t buf[bufsz];                                                   \
+        _stream.readBytes(buf, bufsz);                                        \
+        REQUIRE(memcmp(buf, _str, bufsz) == 0);                               \
+    }                                                                         //
+
+TEST_CASE("EncryptedStream round-trip", "[streams]",) {
+    auto type = GENERATE(
+        DS::EncryptedStream::Type::e_btea,
+        DS::EncryptedStream::Type::e_xtea
+    );
+
+    DS::BufferStream base;
+    {
+        DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_write, type);
+        WRITE_STRING(stream, "Small"); // Purposefully take up less than a full block
+        WRITE_STRING(stream, "!! "); // Complete the block from the previous write
+        WRITE_STRING(stream, "BlockSZ!"); // A full block
+        WRITE_STRING(stream, " ... And finally, something longer than a single block!");
+    }
+    base.seek(0, SEEK_SET);
+    {
+        DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_read);
+        CHECK_STRING(stream, "Small");
+        CHECK_STRING(stream, "!! ");
+        CHECK_STRING(stream, "BlockSZ!");
+        CHECK_STRING(stream, " ... And finally, something longer than a single block!");
+    }
+    base.seek(0, SEEK_SET);
+    {
+        DS::EncryptedStream stream(&base, DS::EncryptedStream::Mode::e_read);
+        CHECK_STRING(stream, "Small!! BlockSZ! ... And finally, something longer than a single block!");
+    }
+}
+
+TEST_CASE("EncryptedStream Magic Strings", "[streams]")
+{
+    SECTION("whatdoyousee") {
+        const char buffer[] { "whatdoyousee\x0\x0\x0\x0" };
+        DS::BufferStream base(buffer, sizeof(buffer));
+        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_xtea);
+    }
+
+    SECTION("BriceIsSmart") {
+        const char buffer[] { "BriceIsSmart\x0\x0\x0\x0" };
+        DS::BufferStream base(buffer, sizeof(buffer));
+        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_xtea);
+    }
+
+    SECTION("notthedroids") {
+        const char buffer[] { "notthedroids\x0\x0\x0\x0" };
+        DS::BufferStream base(buffer, sizeof(buffer));
+        REQUIRE(DS::EncryptedStream::CheckEncryption(&base) == DS::EncryptedStream::Type::e_btea);
+    }
+}

--- a/streams.cpp
+++ b/streams.cpp
@@ -22,6 +22,27 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+bool DS::Stream::readLine(void* buffer, size_t count)
+{
+    DS_ASSERT(count >= 1);
+    char* outp = reinterpret_cast<char*>(buffer);
+    char* endp = outp + count - 1;
+    bool eof = false;
+
+    while (outp < endp) {
+        ssize_t nread = readBytes(outp, 1);
+        if (nread == 0) {
+            eof = true;
+            break;
+        }
+        char c = *outp++;
+        if (c == '\n')
+            break;
+    }
+    *outp = 0;
+    return !eof;
+}
+
 ST::string DS::Stream::readString(size_t length, DS::StringType format)
 {
     if (format == e_StringUTF16) {

--- a/streams.cpp
+++ b/streams.cpp
@@ -308,9 +308,7 @@ DS::EncryptedStream::EncryptedStream(
     switch (mode) {
     case Mode::e_read:
         base->readBytes(header, sizeof(header));
-        if (memcmp(header, "whatdoyousee", 12) == 0)
-            m_type = DS::EncryptedStream::Type::e_tea;
-        else if (memcmp(header, "BriceIsSmart", 12) == 0)
+        if (memcmp(header, "whatdoyousee", 12) == 0 || memcmp(header, "BriceIsSmart", 12) == 0)
             m_type = DS::EncryptedStream::Type::e_tea;
         else if (memcmp(header, "notthedroids", 12) == 0)
             m_type = DS::EncryptedStream::Type::e_xxtea;
@@ -330,6 +328,14 @@ DS::EncryptedStream::EncryptedStream(
 
 DS::EncryptedStream::~EncryptedStream()
 {
+    close();
+}
+
+void DS::EncryptedStream::close()
+{
+    if (m_base == nullptr)
+        return;
+
     if (m_mode == Mode::e_write) {
         if (m_pos % sizeof(m_buffer) != 0)
             cryptFlush();
@@ -344,6 +350,8 @@ DS::EncryptedStream::~EncryptedStream()
         }
         m_base->write<uint32_t>(m_size);
     }
+
+    m_base = nullptr;
 }
 
 std::optional<DS::EncryptedStream::Type> DS::EncryptedStream::CheckEncryption(const char* filename)
@@ -362,9 +370,7 @@ std::optional<DS::EncryptedStream::Type> DS::EncryptedStream::CheckEncryption(DS
     stream->readBytes(header, sizeof(header));
     stream->seek(pos, SEEK_SET);
 
-    if (memcmp(header, "whatdoyousee", sizeof(header)) == 0)
-        return DS::EncryptedStream::Type::e_tea;
-    if (memcmp(header, "BriceIsSmart", sizeof(header)) == 0)
+    if (memcmp(header, "whatdoyousee", sizeof(header)) == 0 || memcmp(header, "BriceIsSmart", sizeof(header)) == 0)
         return DS::EncryptedStream::Type::e_tea;
     if (memcmp(header, "notthedroids", sizeof(header)) == 0)
         return DS::EncryptedStream::Type::e_xxtea;

--- a/streams.cpp
+++ b/streams.cpp
@@ -431,7 +431,7 @@ void DS::EncryptedStream::xteaDecipher(uint32_t* buf) const
     for (size_t i = 0; i < 32; i++) {
         second -= (((first >> 5) ^ (first << 4)) + first)
                 ^ (m_key[(key >> 11) & 3] + key);
-        key += 0x61C88647;
+        key -= 0x9E3779B9;
         first -= (((second >> 5) ^ (second << 4)) + second)
                ^ (m_key[key & 3] + key);
     }
@@ -446,7 +446,7 @@ void DS::EncryptedStream::xteaEncipher(uint32_t* buf) const
     for (size_t i = 0; i < 32; i++) {
         first += (((second >> 5) ^ (second << 4)) + second)
                ^ (m_key[key & 3] + key);
-        key -= 0x61C88647;
+        key += 0x9E3779B9;
         second += (((first >> 5) ^ (first << 4)) + first)
                 ^ (m_key[(key >> 11) & 3] + key);
     }

--- a/streams.h
+++ b/streams.h
@@ -287,8 +287,8 @@ namespace DS
 
         enum class Type
         {
-            e_btea,
-            e_xtea,
+            e_xxtea,
+            e_tea,
         };
 
     protected:
@@ -300,10 +300,10 @@ namespace DS
         Type m_type;
         Mode m_mode;
 
-        void bteaDecipher(uint32_t* buf, uint32_t num) const;
-        void bteaEncipher(uint32_t* buf, uint32_t num) const;
-        void xteaDecipher(uint32_t* buf) const;
-        void xteaEncipher(uint32_t* buf) const;
+        void xxteaDecipher(uint32_t* buf, uint32_t num) const;
+        void xxteaEncipher(uint32_t* buf, uint32_t num) const;
+        void teaDecipher(uint32_t* buf) const;
+        void teaEncipher(uint32_t* buf) const;
         void cryptFlush();
 
     public:

--- a/streams.h
+++ b/streams.h
@@ -64,6 +64,8 @@ namespace DS
             return static_cast<tp>(value);
         }
 
+        bool readLine(void* buffer, size_t count);
+
         ST::string readString(size_t length, DS::StringType format = e_StringRAW8);
         ST::string readSafeString(DS::StringType format = e_StringRAW8);
 

--- a/streams.h
+++ b/streams.h
@@ -316,6 +316,8 @@ namespace DS
         static std::optional<Type> CheckEncryption(const char* filename);
         static std::optional<Type> CheckEncryption(DS::Stream* stream);
 
+        void close();
+
         Type getEncType() const { return m_type; }
         void setKeys(const uint32_t* keys);
 
@@ -327,6 +329,9 @@ namespace DS
         uint32_t size() const override { return m_size; }
         bool atEof() override { return m_pos == m_size; }
         void flush() override { m_base->flush(); }
+
+        EncryptedStream& operator =(const EncryptedStream& copy) = delete;
+        EncryptedStream& operator =(EncryptedStream&& move) = delete;
     };
 }
 


### PR DESCRIPTION
H-uru/Plasma#1450 changed the meaning of `/LocalData` to "use the local PRPs and Python files" but still rely on the server's SDL. This means that clients either need to use the new `/LocalSDL` flag to use their own SDL, which is known to be dangerous, or we need to make it easier to get the known correct SDL to clients connecting to DirtSand.

Therefore, this adds the ability for DirtSand to automatically send down the SDL it is using internally to clients. It uses the very old auth secure preloader functionality, so it is compatible with all known clients. Most SDL files are quite small, which results in fairly poor download performance. Further, AuthSrv downloads are not compressed. So, I elected to give DirtSand the ability to write out its own SDL file containing all known state descriptors and omitting irrelevant comments and whitespace to give an optimal experience for users.

The last two commits could be deferred to another pull request, but I suspected some of the excess copying and memory management might be remarked upon, so I included those ideas for completeness' sake.