### PR TITLE
Fix dockersand restart directives.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   # case.
   db:
     image: postgres:13-alpine
-    restart: always
+    restart: on-failure
     volumes:
       - db:/var/lib/postgresql/data/
 
@@ -39,6 +39,7 @@ services:
         args:
           - BUILD_TYPE=release
     depends_on: [db]
+    restart: on-failure
 
     # All dirtsand services need this incantation so that the console doesn't hang the container.
     stdin_open: true


### PR DESCRIPTION
The previous values would cause the postgres container to restart when, for example, the computer was restarted. The dirtsand container was left unrestarted. We don't want to automatically restart the containers when the computer boots up, I expect, and we definitely want for the containers to have the same restart policy. It seems like the best approach is to restart the containers when they crash only.