### PR TITLE
Fix a segfault related to clients connecting with the wrong build ID.

### DIFF
--- a/AuthServ/AuthServer.cpp
+++ b/AuthServ/AuthServer.cpp
@@ -1052,7 +1052,7 @@ void wk_authWorker(DS::SocketHandle sockp)
                 ST::printf(stderr, "[Auth] Failure in poll: {}\n", strerror(errno));
                 throw DS::SockHup();
             }
-            if (result == 0 || fds[0].revents & POLLHUP)
+            if (result == 0 || fds[0].revents & (POLLERR | POLLHUP | POLLNVAL) || fds[1].revents & (POLLERR | POLLNVAL))
                 throw DS::SockHup();
 
             if (fds[0].revents & POLLIN)

--- a/GameServ/GameServer.cpp
+++ b/GameServ/GameServer.cpp
@@ -269,7 +269,7 @@ void wk_gameWorker(DS::SocketHandle sockp)
                            strerror(errno));
                 throw DS::SockHup();
             }
-            if (result == 0 || fds[0].revents & POLLHUP)
+            if (result == 0 || fds[0].revents & (POLLERR | POLLHUP | POLLNVAL) || fds[1].revents & (POLLERR | POLLNVAL))
                 throw DS::SockHup();
 
             if (fds[0].revents & POLLIN)


### PR DESCRIPTION
Somehow, when repeated connection attempts came in from a single client with a bad build ID, we would hit a segfault where the auth client's broadcast channel would have an invalid message in it. It is unclear how this message got in the channel, but I did notice that `poll()` is returning that the client's socket is `POLLNVAL`. Treating `POLLNVAL` as a regular hangup seems to prevent the problem.