### PR TITLE
Implement `makeSafeForNet` more thoroughly for avatar-related messages

### DIFF
--- a/PlasMOUL/Avatar/ArmatureBrain.h
+++ b/PlasMOUL/Avatar/ArmatureBrain.h
@@ -28,6 +28,8 @@ namespace MOUL
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
 
+        virtual bool makeSafeForNet() { return true; }
+
     protected:
         ArmatureBrain(uint16_t type) : Creatable(type) { }
     };

--- a/PlasMOUL/Avatar/AvBrainGeneric.cpp
+++ b/PlasMOUL/Avatar/AvBrainGeneric.cpp
@@ -89,3 +89,15 @@ void MOUL::AvBrainGeneric::write(DS::Stream* stream) const
     stream->write<uint8_t>(m_bodyUsage);
     m_recipient.write(stream);
 }
+
+bool MOUL::AvBrainGeneric::makeSafeForNet()
+{
+    // These fields can contain arbitrary messages,
+    // so we must check them before sending the brain to other clients.
+    // The client never uses these fields for brains sent over the network though,
+    // so for simplicity, don't allow them over the network at all.
+    // If this causes issues, we could specifically allow NotifyMsg
+    // (the only message type that the client puts in these fields)
+    // or recursively call makeSafeForNet() on the messages.
+    return m_startMessage == nullptr && m_endMessage == nullptr;
+}

--- a/PlasMOUL/Avatar/AvBrainGeneric.h
+++ b/PlasMOUL/Avatar/AvBrainGeneric.h
@@ -31,6 +31,8 @@ namespace MOUL
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
 
+        bool makeSafeForNet() override;
+
     public:
         std::vector<AnimStage*> m_stages;
         int32_t m_curStage;

--- a/PlasMOUL/Avatar/AvTask.cpp
+++ b/PlasMOUL/Avatar/AvTask.cpp
@@ -64,3 +64,8 @@ void MOUL::AvTaskBrain::write(DS::Stream* stream) const
 {
     Factory::WriteCreatable(stream, m_brain);
 }
+
+bool MOUL::AvTaskBrain::makeSafeForNet()
+{
+    return m_brain == nullptr || m_brain->makeSafeForNet();
+}

--- a/PlasMOUL/Avatar/AvTask.h
+++ b/PlasMOUL/Avatar/AvTask.h
@@ -24,6 +24,9 @@ namespace MOUL
 {
     class AvTask : public Creatable
     {
+    public:
+        virtual bool makeSafeForNet() { return true; }
+
     protected:
         AvTask(uint16_t type) : Creatable(type) { }
     };
@@ -83,6 +86,8 @@ namespace MOUL
 
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
+
+        bool makeSafeForNet() override;
 
     public:
         ArmatureBrain* m_brain;

--- a/PlasMOUL/Avatar/CoopCoordinator.cpp
+++ b/PlasMOUL/Avatar/CoopCoordinator.cpp
@@ -66,3 +66,11 @@ void MOUL::CoopCoordinator::write(DS::Stream* s) const
     s->writeSafeString(m_synchBone);
     s->write<bool>(m_autoStartGuest);
 }
+
+bool MOUL::CoopCoordinator::makeSafeForNet()
+{
+    return (m_hostBrain == nullptr || m_hostBrain->makeSafeForNet())
+        && (m_guestBrain == nullptr || m_guestBrain->makeSafeForNet())
+        // This can only be LinkToAgeMsg.
+        && (m_acceptMsg == nullptr || (m_acceptMsg->type() == ID_LinkToAgeMsg && m_acceptMsg->makeSafeForNet()));
+}

--- a/PlasMOUL/Avatar/CoopCoordinator.cpp
+++ b/PlasMOUL/Avatar/CoopCoordinator.cpp
@@ -71,6 +71,5 @@ bool MOUL::CoopCoordinator::makeSafeForNet()
 {
     return (m_hostBrain == nullptr || m_hostBrain->makeSafeForNet())
         && (m_guestBrain == nullptr || m_guestBrain->makeSafeForNet())
-        // This can only be LinkToAgeMsg.
-        && (m_acceptMsg == nullptr || (m_acceptMsg->type() == ID_LinkToAgeMsg && m_acceptMsg->makeSafeForNet()));
+        && (m_acceptMsg == nullptr || m_acceptMsg->makeSafeForNet());
 }

--- a/PlasMOUL/Avatar/CoopCoordinator.h
+++ b/PlasMOUL/Avatar/CoopCoordinator.h
@@ -35,6 +35,8 @@ namespace MOUL
         void read(DS::Stream* s) override;
         void write(DS::Stream* s) const override;
 
+        virtual bool makeSafeForNet();
+
     public:
         Key m_hostKey, m_guestKey;
         AvBrainCoop* m_hostBrain;

--- a/PlasMOUL/Messages/AvTaskMsg.cpp
+++ b/PlasMOUL/Messages/AvTaskMsg.cpp
@@ -40,6 +40,11 @@ void MOUL::AvTaskMsg::write(DS::Stream* stream) const
     }
 }
 
+bool MOUL::AvTaskMsg::makeSafeForNet()
+{
+    return m_task == nullptr || m_task->makeSafeForNet();
+}
+
 void MOUL::AvPushBrainMsg::read(DS::Stream* stream)
 {
     AvTaskMsg::read(stream);
@@ -50,4 +55,10 @@ void MOUL::AvPushBrainMsg::write(DS::Stream* stream) const
 {
     AvTaskMsg::write(stream);
     Factory::WriteCreatable(stream, m_brain);
+}
+
+bool MOUL::AvPushBrainMsg::makeSafeForNet()
+{
+    return MOUL::AvTaskMsg::makeSafeForNet()
+        && (m_brain == nullptr || m_brain->makeSafeForNet());
 }

--- a/PlasMOUL/Messages/AvTaskMsg.h
+++ b/PlasMOUL/Messages/AvTaskMsg.h
@@ -32,6 +32,8 @@ namespace MOUL
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
 
+        bool makeSafeForNet() override;
+
     protected:
         AvTaskMsg(uint16_t type) : AvatarMsg(type), m_task() { }
 
@@ -46,6 +48,8 @@ namespace MOUL
 
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
+
+        bool makeSafeForNet() override;
 
     protected:
         AvPushBrainMsg(uint16_t type) : AvTaskMsg(type), m_brain() { }

--- a/PlasMOUL/Messages/AvatarMsg.cpp
+++ b/PlasMOUL/Messages/AvatarMsg.cpp
@@ -73,14 +73,7 @@ void MOUL::AvCoopMsg::write(DS::Stream* s) const
 
 bool MOUL::AvCoopMsg::makeSafeForNet()
 {
-    if (m_coordinator) {
-        if (m_coordinator->m_acceptMsg) {
-            // This can only be LinkToAgeMsg.
-            // Indeed, this will be the only way to send that msg over the wire
-            return m_coordinator->m_acceptMsg->type() == ID_LinkToAgeMsg;
-        }
-    }
-    return true;
+    return m_coordinator == nullptr || m_coordinator->makeSafeForNet();
 }
 
 void MOUL::AvTaskSeekDoneMsg::read(DS::Stream* stream)

--- a/PlasMOUL/Messages/LoadAvatarMsg.cpp
+++ b/PlasMOUL/Messages/LoadAvatarMsg.cpp
@@ -46,3 +46,9 @@ void MOUL::LoadAvatarMsg::write(DS::Stream* stream) const
     }
     stream->writeSafeString(m_userString);
 }
+
+bool MOUL::LoadAvatarMsg::makeSafeForNet()
+{
+    return MOUL::LoadCloneMsg::makeSafeForNet()
+        && (m_initTask == nullptr || m_initTask->makeSafeForNet());
+}

--- a/PlasMOUL/Messages/LoadAvatarMsg.h
+++ b/PlasMOUL/Messages/LoadAvatarMsg.h
@@ -30,6 +30,8 @@ namespace MOUL
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
 
+        bool makeSafeForNet() override;
+
     public:
         bool m_isPlayer;
         Key m_spawnPoint;

--- a/PlasMOUL/Messages/LoadCloneMsg.cpp
+++ b/PlasMOUL/Messages/LoadCloneMsg.cpp
@@ -44,3 +44,8 @@ void MOUL::LoadCloneMsg::write(DS::Stream* stream) const
     stream->write<bool>(m_isLoading);
     Factory::WriteCreatable(stream, m_triggerMsg);
 }
+
+bool MOUL::LoadCloneMsg::makeSafeForNet()
+{
+    return m_triggerMsg == nullptr || m_triggerMsg->makeSafeForNet();
+}

--- a/PlasMOUL/Messages/LoadCloneMsg.h
+++ b/PlasMOUL/Messages/LoadCloneMsg.h
@@ -29,6 +29,8 @@ namespace MOUL
         void read(DS::Stream* stream) override;
         void write(DS::Stream* stream) const override;
 
+        bool makeSafeForNet() override;
+
     public:
         Key m_cloneKey, m_requestorKey;
         bool m_validMsg, m_isLoading;


### PR DESCRIPTION
`AvBrainGeneric` can contain arbitrary messages, and so can (indirectly) many avatar-related messages that contain a brain and/or task. This change ensures that such nested messages are checked for net-safety.

H-uru/Plasma#1550 implements similar checks on the receiving end in the client.