### PR TITLE
Fix problems related to dockersand.bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ testing server much more quickly and easily on Windows, Mac, or Linux.
     the base docker container name. You can overwrite this usage by setting the
     $ProjectName variable in `dockersand.ps1` (for Windows) or the PROJECT_NAME
     variable in `dockersand.sh` (for *nix) to the desired base container name.
+    - Windows users: By default, Windows Terminal may open a *Windows PowerShell*
+    prompt. Running any `./dockersand` commands in *Windows PowerShell* may trigger
+    security exceptions. You can avoid these by using the *Command Prompt* or by
+    running `Unblock-File dockersand.ps1`.
 
 4) Once the build is complete, run `./dockersand start` to start the new containers
 for the database and the dirtsand server. Once this command has been run, you should

--- a/dockersand.bat
+++ b/dockersand.bat
@@ -1,1 +1,1 @@
-powershell.exe -ExecutionPolicy Bypass dockersand.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass dockersand.ps1

--- a/dockersand.bat
+++ b/dockersand.bat
@@ -1,1 +1,2 @@
-powershell.exe -NoProfile -ExecutionPolicy Bypass dockersand.ps1
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File dockersand.ps1


### PR DESCRIPTION
Got a report on discord:

```
PS D:\dirtsand> ./dockersand build
./dockersand : File D:\dirtsand\dockersand.ps1 cannot be loaded because running scripts is disabled on this system.
For more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
At line:1 char:1
+ ./dockersand build
+ ~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess
```

Assuming that `./dockersand` is mapping to `dockersand.bat`, the default policy might be messing with us. Most all resources online suggest using `NoProfile` when using helper scripts to launch PowerShell, so let's do it.