### PR TITLE
Optional backwards compatibility with older clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ set(DS_HOOD_INST_NAME       "Neighborhood"
 set(DS_HOOD_POP_THRESHOLD   "20"
     CACHE STRING "Default Neighborhood Max Population")
 
+option(DS_OU_COMPATIBLE "Enable backwards compatibility with older game clients" OFF)
+
 add_compile_options(-Wall -Wextra -Wno-unused-parameter)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
@@ -133,6 +135,7 @@ add_library(dirtsand STATIC ${dirtsand_SOURCES} ${SDL_SOURCES} ${PlasMOUL_SOURCE
 
 target_compile_definitions(dirtsand PRIVATE
     $<$<CONFIG:Debug>:DEBUG>
+    $<$<BOOL:${DS_OU_COMPATIBLE}>:DS_OU_COMPATIBLE>
     PRODUCT_BRANCH_ID=${PRODUCT_BRANCH_ID}
     PRODUCT_BUILD_ID=${PRODUCT_BUILD_ID}
     PRODUCT_BUILD_TYPE=${PRODUCT_BUILD_TYPE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ ARG PRODUCT_UUID=ea489821-6c35-4bd0-9dae-bb17c585e680
 ARG DS_HOOD_USER_NAME=DS
 ARG DS_HOOD_INST_NAME=Neighborhood
 ARG DS_HOOD_POP_THRESHOLD=20
+ARG DS_OU_COMPATIBLE=ON
 
 RUN \
     mkdir -p /opt/dirtsand/db && cp dirtsand/db/*.sql /opt/dirtsand/db && \
@@ -59,8 +60,8 @@ RUN \
         -DPRODUCT_BRANCH_ID=${PRODUCT_BRANCH_ID} -DPRODUCT_BUILD_ID=${PRODUCT_BUILD_ID} \
         -DPRODUCT_BUILD_TYPE=${PRODUCT_BUILD_TYPE} -DPRODUCT_UUID=${PRODUCT_UUID} \
         -DDS_HOOD_USER_NAME=${DS_HOOD_USER_NAME} -DDS_HOOD_INST_NAME=${DS_HOOD_INST_NAME} \
-        -DDS_HOOD_POP_THRESHOLD=${DS_HOOD_POP_THRESHOLD} -DENABLE_TESTS=OFF \
-        -B dirtsand/build -S dirtsand && \
+        -DDS_HOOD_POP_THRESHOLD=${DS_HOOD_POP_THRESHOLD} -DDS_OU_COMPATIBLE=${DS_OU_COMPATIBLE} \
+        -DENABLE_TESTS=OFF -B dirtsand/build -S dirtsand && \
     cmake --build dirtsand/build --parallel && cmake --build dirtsand/build --target install && \
     mkdir -p /opt/dirtsand/etc && \
     \

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -145,6 +145,7 @@ Server.Status "${SHARD_STATUS_URL:-http://${DS_HOST:-127.0.0.1}:8080/welcome}"
 
 # Shard front-end server address.
 Server.Gate.Host "${DS_HOST:-127.0.0.1}"
+Server.Auth.Host "${DS_HOST:-127.0.0.1}"
 Server.Port ${SHARD_PORT:-14617}
 
 # Shard name - NOTE: this is currently not visible anywhere.


### PR DESCRIPTION
Currently, OU clients don't handle the Auth2Cli_ServerCaps message, and that results in the network stream getting into a bad state where the client throws an error and gives us.

This compatibility hack from dgelessus is interpreted as a ServerCaps response by newer clients that understand that message, and as a harmless file download response by older clients which don't.