### PR TITLE
Replace Ubuntu 20.04 runners with 24.04.

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Ubuntu 20.04 Github-hosted runners are now deprecated.