### PR TITLE
FixProposedByPrad

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     apk add bash libstdc++ openssl postgresql-client readline zlib && \
     \
     adduser --disabled-password --no-create-home dirtsand && \
-    mkdir -p /opt/dirtsand && chown -R dirtsand /opt/dirtsand
+    mkdir -p /opt/dirtsand && chown -R dirtsand:dirtsand /opt/dirtsand
 
 FROM run_env AS build_env_debug
 ENV BUILD_TYPE=Debug
@@ -37,7 +37,7 @@ RUN \
     mkdir -p /usr/src && cd /usr/src && \
     git clone --depth 1 https://github.com/zrax/string_theory.git && \
     cmake -DCMAKE_BUILD_TYPE=Release -DST_BUILD_TESTS=OFF -B string_theory/build -S string_theory && \
-    cmake --build string_theory/build --parallel && cmake --build string_theory/build --target install && \
+    cmake --build string_theory/build --parallel 1 && cmake --build string_theory/build --target install && \
     \
     git clone --depth 1 https://github.com/H-uru/Plasma.git
 
@@ -62,14 +62,14 @@ RUN \
         -DDS_HOOD_USER_NAME=${DS_HOOD_USER_NAME} -DDS_HOOD_INST_NAME=${DS_HOOD_INST_NAME} \
         -DDS_HOOD_POP_THRESHOLD=${DS_HOOD_POP_THRESHOLD} -DDS_OU_COMPATIBLE=${DS_OU_COMPATIBLE} \
         -DENABLE_TESTS=OFF -B dirtsand/build -S dirtsand && \
-    cmake --build dirtsand/build --parallel && cmake --build dirtsand/build --target install && \
+    cmake --build dirtsand/build --parallel 1 && cmake --build dirtsand/build --target install && \
     mkdir -p /opt/dirtsand/etc && \
     \
     mkdir -p /opt/dirtsand/lib/moul-scripts/SDL && mkdir -p /opt/dirtsand/lib/moul-scripts/dat && \
     cp /usr/src/Plasma/Scripts/SDL/*.sdl /opt/dirtsand/lib/moul-scripts/SDL && \
     cp /usr/src/Plasma/Scripts/dat/*.age /opt/dirtsand/lib/moul-scripts/dat && \
     \
-    chown -R dirtsand /opt/dirtsand
+    chown -R dirtsand:dirtsand /opt/dirtsand
 
 FROM run_env AS run_env_debug
 RUN apk add gdb musl-dbg


### PR DESCRIPTION
https://discord.com/channels/282045216221822978/282046743338811392/1424555618668384339 up to https://discord.com/channels/282045216221822978/282046743338811392/1424583169750863902 .

Prad wrote:
> Only thing I remember having had to change there (both on Windows 7 Docker-Toolbox and Ubuntu 20.04 Docker) was replace `chown -R dirtsand /opt/dirtsand` with `chown -R dirtsand:dirtsand /opt/dirtsand` ... the script is executed as root user inside the container, but `chown dirtsand <filepath>` only changes the user, not the group the user is in, so you end up with files belonging to `dirtsand:root` which the user `dirtsand:dirtsand` (defined as USER dirtsand in line 83) doesn't have access to ... I had to delete the erratic containers and re-build dockersand with the modified DockerFile (running the bat file again with build as argument) ...

Prad wrote:
> AH, and I had to change `cmake --build string_theory/build --parallel` into `cmake --build string_theory/build --parallel 1` as well as `cmake --build dirtsand/build --parallel` into `cmake --build dirtsand/build --parallel 1` ... for some reason multithreaded builds of dockersand never worked well for me (neither on windows 7 with docker-toolbox nor on ubuntu 20.04 with docker) ... I don't really know why alpine Linux is really struggling with multithreaded builds of programs on sufficiently modern machines) ...

The Desktop computer I installed dirtsand on, run Windows 11 Pro x64, and I had an issue that disallowed me to build dockersand; the fix proposed by Prad worked for me too.