### PR TITLE
Fix compatibility with CMake 4.0+.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with dirtsand.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.14)
 project(dirtsand)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -180,19 +180,10 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/bin/docker-entrypoint.sh ${CMAKE_SOURCE_DIR
 install(FILES static_ages.ini
         DESTINATION ".")
 
-# The tests use the FetchContent module, which was added in CMake 3.11.
-include(CMakeDependentOption)
-cmake_dependent_option(
-    ENABLE_TESTS
-    "Enable building and running unit tests"
-    ON
-    "NOT ${CMAKE_VERSION} VERSION_LESS 3.11"
-    OFF
-)
-
 # clang-tidy related rules and targets
 include(TidyRules.cmake)
 
+option(ENABLE_TESTS "Enable building and running unit tests" ON)
 if(ENABLE_TESTS)
     enable_testing()
     add_subdirectory(Tests)


### PR DESCRIPTION
CMake 4.0 has dropped support for anything older than CMake 3.5. While we could simply bump our minimum requirement from 3.4 to 3.5, that doesn't really give us any breathing room for CMake's next round of removals, whenever that might happen. The DS tests require the FetchContent module and make use of `FetchContent_MakeAvailable`, which was added in CMake 3.14. So, this bumps our minimum to 3.14 and removes the version gate for the tests, which was incidentally incorrect - FetchContent was indeed added in 3.11, but we used functionality added in 3.14.

Ubuntu 20.04 ships with CMake 3.16, and that's 6 years old at this point, so CMake 3.14 feels like a reasonable minimum.